### PR TITLE
Undefined names: import pickle, zlib

### DIFF
--- a/videoflow/environments/zeromq.py
+++ b/videoflow/environments/zeromq.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import absolute_import
 
 import numpy as np
+import pickle
+import zlib
 import zmq
 
 REFERENCE_SOCKET_NUMBER = 5000

--- a/videoflow/utils/downloader.py
+++ b/videoflow/utils/downloader.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+from contextlib import closing
 import sys
 import hashlib
 import os


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/videoflow/videoflow on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./setup.py:18:15: F821 undefined name '__version__'
    version = __version__,
              ^
./videoflow/environments/zeromq.py:27:14: F821 undefined name 'zlib'
    object = zlib.decompress(message)
             ^
./videoflow/environments/zeromq.py:28:12: F821 undefined name 'pickle'
    return pickle.loads(object)
           ^
./videoflow/environments/zeromq.py:34:14: F821 undefined name 'pickle'
    object = pickle.dumps(obj, protocol)
             ^
./videoflow/environments/zeromq.py:35:25: F821 undefined name 'zlib'
    compressed_object = zlib.compress(object)
                        ^
./videoflow/processors/vision/trackers.py:252:18: F821 undefined name 'probability_factory'
            mf = probability_factory(tm, self.square_dims, self.frame_shape)
                 ^
./videoflow/utils/downloader.py:52:14: F821 undefined name 'closing'
        with closing(urlopen(url, data)) as response, open(filename, 'wb') as fd:
             ^
7     F821 undefined name '__version__'
7
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree