### PR TITLE
Add FileNotFoundError for VideoFileReader, ImageProducer & Videofile…

### DIFF
--- a/docs/source/user-documentation/common-patterns.rst
+++ b/docs/source/user-documentation/common-patterns.rst
@@ -9,7 +9,7 @@ Assume that we want to run the following flow in a machine that has
 
     from videoflow.producers import IntProducer
     from videoflow.processors import IdentityProcessor
-    from videoflow.consumers.import CommandlineConsumer
+    from videoflow.consumers import CommandlineConsumer
 
     A = IntProducer(0, 40, fps = 30)
     B = IdentityProcessor(fps = 300)(A)

--- a/videoflow/consumers/video.py
+++ b/videoflow/consumers/video.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+import os
+import errno
 import cv2
 import numpy as np
 
@@ -20,6 +22,8 @@ class VideofileWriter(ConsumerNode):
     '''
 
     def __init__(self, video_file : str, swap_channels : bool = True, fps : int = 30):
+        if not os.path.isfile(video_file):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), video_file)
         if video_file[-4:] != '.avi':
             raise ValueError('Only .avi format is supported')
         self._video_file = video_file

--- a/videoflow/producers/video.py
+++ b/videoflow/producers/video.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+import os
+import errno
 import logging 
 
 import cv2
@@ -17,6 +19,8 @@ class ImageProducer(ProducerNode):
     '''
 
     def __init__(self, image_path : str):
+        if not os.path.isfile(image_path):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), image_path)
         self._image_path = image_path
         self._image_returned = False
         super(ImageProducer, self).__init__()
@@ -149,7 +153,7 @@ class VideoUrlReader(VideostreamReader):
     from the video url each time ``next`` is called.
 
     - Arguments:
-        - device_id: id of the video device connected to the computer
+        - url: url of the video stream
         - nb_frames: number of frames to process. -1 means all of them
     '''
     def __init__(self, url : str, nb_frames : int = -1, nb_retries = 0):
@@ -178,6 +182,8 @@ class VideoFileReader(VideostreamReader):
         - nb_frames: number of frames to process. -1 means all of them
     '''
     def __init__(self, video_file : str, swap_channels : bool = False, nb_frames = -1):
+        if not os.path.isfile(video_file):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), video_file)
         super(VideoFileReader, self).__init__(video_file, swap_channels = swap_channels, nb_frames = nb_frames, nb_retries = 0)
 
 # Here for the sake of not breaking


### PR DESCRIPTION
Hi! I have added `FileNotFoundError` Exception which would be raised when an invalid `filepath` is passed as a parameter. It would be easier for developers to debug.

The Error would be like:
`    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), video_file)
FileNotFoundError: [Errno 2] No such file or directory: './videos/test.mp4'`

Here, `./videos/test.mp4` is not a valid file.