### PR TITLE
Move the toy solutions into core and run them as integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ __pycache__/
 # rendered k8s manifests (videoflow deploy --render-only)
 /manifests/
 
+# Per-machine solution configs: generated from config.template.yaml and full of
+# absolute paths. config.example.yaml and config.template.yaml are the tracked ones.
+solutions/*/config.yaml
+
+# Solution run artifacts (work_dir defaults to ./out next to the config).
+solutions/*/out/
+*_nocommit*
+
 # Folder with models downloaded
 models/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,35 @@ convention below follows from that.
 | `spec/` | Language-agnostic protocol contract: `PROTOCOL.md`, `proto/`, golden `vectors/`, `rfcs/` |
 | `docker/`, `k8s/` | Base images (CPU + CUDA) and dev broker manifests |
 | `docs/` | Sphinx site (`docs/source/`) |
+| `solutions/` | The three dependency-free `toy_*` solutions — deployable apps that double as the end-to-end test fixtures (see below) |
 | `tests/`, `tests/integration/`, `examples/` | Unit tests, broker-backed tests, runnable examples |
 
-Sibling repo: `../videoflow-contrib` — community components and end-to-end solutions. It has its
+Sibling repo: `../videoflow-contrib` — community components and the ML solutions. It has its
 own `CLAUDE.md`.
+
+## The toy solutions are the end-to-end tests
+
+`solutions/{toy_calculator,toy_fusion,toy_router}` are complete, deployable solutions built from
+core nodes only — no models, no footage, no `videoflow_contrib` packages — and
+`tests/integration/test_toy_solutions.py` runs all three on every CI build. Between them they
+cover the framework paths no in-process test reaches:
+
+| Solution | Flow type | What it gates | Success artifact |
+|---|---|---|---|
+| `toy_calculator` | BATCH | fan-out, trace join re-aligning branches, competing replicas, stateful aggregation, two-parent consumer, `metadata=True` consumer, prep hook | `report.json` → `matches_expected: true` |
+| `toy_router` | BATCH | `partition_by` routing, `ctx.set_partition_key`, `async def process`, replica identity, idempotent sink | `counts.json` → `matches_expected` **and** `sticky` |
+| `toy_fusion` | REALTIME | independent producers fused by event time, `tolerance_ms`/`quorum`/`collect`, unbounded sources, `ctx.input_info` | `fusion_summary.json` → complete moments |
+
+Two things to know before touching them:
+
+- **They are tests *and* published examples.** A change to a graph, a node or a config key means
+  updating the solution's `README.md`, its `config.example.yaml`/`config.template.yaml`, and the
+  test's config dict together. Keep every stream short enough that a full run stays ~10s.
+- **The test copies each solution to a tmpdir and drives it with `videoflow run-local`.** That is
+  not incidental: `load_flow` calls `build_flow()` with no arguments, so a solution always reads
+  the `config.yaml` next to its own module (`--config` reaches only `prepare.py`), and all three
+  ship a `common.py`, so importing two into one interpreter would collide. Don't "simplify" the
+  test into an in-process `build_flow()` call.
 
 ## Commands
 
@@ -38,6 +63,7 @@ own `CLAUDE.md`.
 uv sync                                        # install (uv is the tool of record)
 uv run pytest --ignore=tests/integration       # unit tests — what the pre-push hook runs
 uv run pytest tests/integration                # needs a live NATS; auto-skipped if absent
+uv run pytest tests/integration/test_toy_solutions.py   # the three solutions/, end to end (~25s)
 uv run mypy                                    # type check (files = ["videoflow"])
 uv run ruff check --fix .                      # lint + import sort
 docker compose up -d                           # dev NATS (:4222) + Redis (:6379)
@@ -252,6 +278,9 @@ finishing, check each of these and update the ones your change invalidates:
 - `spec/PROTOCOL.md` + `spec/vectors/` — the wire format or routing changed (also needs an RFC).
 - `CLAUDE.md` and `.claude/docs/*.md` — conventions, layout, or commands changed.
 - `examples/` — an example is now wrong or misleading.
+- `solutions/` — a toy solution's graph, nodes or config keys changed. Its `README.md`,
+  `config.example.yaml`, `config.template.yaml` and the config dict in
+  `tests/integration/test_toy_solutions.py` all describe the same thing and go stale together.
 - `../videoflow-contrib` — the node contract changed in a way components must follow.
 
 ## Where to look next

--- a/README.md
+++ b/README.md
@@ -127,6 +127,31 @@ python my_flow.py
 
 ---
 
+## Example solutions
+
+[`solutions/`](solutions) holds three complete, deployable applications built
+from core nodes only — no models, no footage, no extra dependencies. They are
+the fastest way to see the whole path (config, prep hook, image, broker, workers,
+teardown) actually work, and the best code to read after this README.
+
+| Solution | Flow type | What it demonstrates |
+|---|---|---|
+| [toy_calculator](solutions/toy_calculator) | BATCH | A diamond over a stream of integers: fan-out, a trace join, competing replicas, stateful aggregation, a two-parent consumer. The smallest complete solution. |
+| [toy_router](solutions/toy_router) | BATCH | Partitioned parallelism: `partition_by` pinning each key to one replica, an `async def process` node, an idempotent sink. |
+| [toy_fusion](solutions/toy_fusion) | REALTIME | Independent producers fused by event time — tolerance, lateness timeout, quorum, collect windows — with unbounded live sources. |
+
+```bash
+cd solutions/toy_calculator
+videoflow run-local toy_calculator.py     # or: videoflow deploy toy_calculator.py
+```
+
+Each writes a self-checking artifact (`report.json`, `counts.json`,
+`fusion_summary.json`) saying whether the distributed run computed the right
+answer — which is also how they serve as the framework's end-to-end test suite,
+run on every CI build by `tests/integration/test_toy_solutions.py`.
+
+---
+
 ## Deploying to Kubernetes
 
 On a dev cluster (k3s / kind / minikube / Docker Desktop), deploying is one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,50 +1,134 @@
-# Roadmap of Videoflow up to v1.0
+# Videoflow roadmap
 
-## v0.3
-- Add a Sequence processor.
-- Add ability to compose subflows.
-- Add processors for:
-    - Top-down human pose estimation.
-    - Semantic segmentation using tensorflow published models.
-    - Pose annotation of images.
-    - Mask annotation of images.
-    - Basic image manipulation operations.
-- Reimplement batch execution engine so that it uses microbadges.
+Current release: **v1.0.0**.
 
-## v0.4
-- Logging of events, flow performance and errors.
-- Allow user to determine what to do when in presence of errors:
-    - Stop flow
-    - Drop error frames and continue
-    - Other?
-- v0.4 is the ground work for v0.5 and v0.9
+The design of record for everything below is [todos/07_gap_analysis.md](todos/07_gap_analysis.md);
+this page is the release-shaped view of it. Nothing here is implemented yet.
 
-## v0.5
-- Commandline tools to detect bottlenecks by reading logs.
-- Commandline tools to debug errors in flow.
+## Where v1.0 stands
 
-## v0.6
-- Automatic detection of bottlenecks
+Videoflow today builds a graph on one machine and runs it on many — one worker per node, locally
+or as a Kubernetes workload — with event-time joins across parents, partitioned routing,
+end-of-stream drain, at-least-once delivery with deduplication and a dead-letter queue,
+large-payload offload, sink idempotency, and a deployment CLI.
 
-## v0.7
-- Automatic scaling/decrease of resources in flow without stopping it.
-- Will require some changes and augmentations to current execution engines.
+The gap is **temporal**. There is windowing for *aligning several parents*, but none for
+*aggregating a single stream over time*; a node emits exactly one output per input, and has no way
+to emit what it has buffered when the stream ends. Most of what a complex video solution has to
+hand-roll today follows from that, and so does most of this roadmap.
 
-## v0.8
-- Processors:
-    - SLAM
-    - Advanced tracking techniques.
-    - Others
+---
 
-## v0.9
-- Flowboard: Something similar to tensorboard, but for flows.
+## v1.0.1 — component fills
 
-## v1.0
-- Nothing new to add here.
+Straight library work with no changes to the framework itself. Ships first because it unblocks
+real solutions today and depends on nothing else.
 
-.
-.
-.
+- **Mp4 video writer** — output format chosen from the file extension, with H.264 for `.mp4` and
+  the current codec preserved for `.avi`. Every solution currently emits video that browsers
+  can't play.
+- **Image-folder and video-folder readers** — iterate a directory of images or videos in sorted
+  order as a single stream. These are declared today but unimplemented.
+- **Pose-estimation base class** — a domain base with standard keypoint constants, so pose
+  components share a contract the way detectors already do.
 
-# v2.0
-- Distributed version of **Videoflow**
+## v1.0.2 — temporal core
+
+The foundation the rest of the roadmap stands on.
+
+**Zero-or-many emission and an end-of-stream hook.** A processor can publish nothing for an input,
+or several outputs, instead of exactly one — a skip signal distinct from `None`, which stays a
+legal payload, plus an emit call usable any number of times per input. A new flush hook runs once
+after every parent has drained and before the node signals end of stream, so a node that has been
+accumulating can emit its final result. Redelivery stays safe: re-running an input produces the
+same outputs with the same identities, so duplicates are still suppressed.
+
+**Windowed processors.** A node can keep the last N items or the last T seconds of its input and
+process against that history rather than a single item, with a read-only window view offering
+nearest-timestamp lookup and time-range slices. The window is the node's own memory of history it
+has already acknowledged, which leaves delivery semantics untouched and makes the contract honest:
+a crash loses the buffered tail and it refills. Per-key windows are available where the stream is
+partitioned by key; a windowed node with several replicas requires a partition key, since
+competing replicas would otherwise each see a random interleaving of the stream.
+
+This changes both the node contract and the protocol's message-identity rules, so it needs an RFC.
+
+## v1.0.3 — triggers and media
+
+**Control inputs.** A parent can be designated as a control (marker) stream rather than a data
+input. It never gates join completeness, it is broadcast to *every* replica instead of being
+routed to one, it arrives through a dedicated callback that never runs concurrently with normal
+processing, and it is delivered promptly even when the data streams are quiet. End of stream is
+driven by the data parents alone, so a trigger source that never ends can't block shutdown, and
+one that ends early can't stop the node. Markers get the same at-least-once delivery as data — a
+missed trigger is a missed event.
+
+**Frame store.** An opt-in store for recent frames held outside the message stream, addressed by
+camera and time, with retention as an expiry. Downstream nodes fetch only the rare frames they
+actually need, instead of every frame flowing through the broker. For batch flows, re-reading the
+source file from disk stays the supported answer; this earns its keep on live streams.
+
+**Event clip writer.** Consumes events, pulls the surrounding pre- and post-roll from the frame
+store, and writes a clip — the end-to-end use case the previous two features exist to serve.
+
+Control inputs change routing and loop behaviour, so this phase needs an RFC.
+
+## v1.0.4 — named output ports
+
+A node can declare several named outputs and return a value for each, and downstream nodes
+subscribe to one port by name. This replaces today's pattern of a node returning a bundle followed
+by a chain of splitter nodes that pull it apart: a subscriber interested in one output no longer
+receives or decodes the others, which is the real bandwidth win, and the intermediate splitter
+workers disappear entirely. Producers get ports too, so a reader can expose its frame and its
+index as separate outputs.
+
+End of stream stays per node rather than per port — all of a node's ports end when the node does,
+and a child subscribed to one port still observes it. Existing single-output flows must stay
+byte-identical in every routing decision; that identity check is the acceptance test for this
+phase, not a passing test suite.
+
+This is the largest single item on the roadmap and needs an RFC. It does not lift the
+single-replica ceiling on event-time joins.
+
+## v1.0.5 — analytics components
+
+Independent of v1.0.4 and buildable alongside it.
+
+- **Line-crossing counter and zone-intrusion detector** — the natural stage after tracking,
+  emitting both running counts and discrete events.
+- **RTSP/RTMP restreamer** — live video out, for solutions whose result is a stream rather than a
+  file.
+- **OCR** — plate and jersey reading.
+
+Rejected: a WebRTC output consumer. Per-viewer signaling and session state don't fit one node per
+worker; restream to a media server and let it terminate WebRTC.
+
+## v2.0 — durable state and event-time completeness
+
+Each of these is large enough to need its own design cycle:
+
+- **Watermarks** and event-time completeness beyond wall-clock timeouts, which needs a notion of
+  progress shared across parallel sources.
+- **Aligned tumbling and session windows**, and event-time timers. The windows in v1.0.2 are a
+  sliding tail, not an aligned window; this is where that gets fixed.
+- **Durable keyed state and checkpointing**, so a replica restart doesn't lose its history. See
+  [todos/08_checkpointing of buffers.md](todos/08_checkpointing%20of%20buffers.md).
+- **Scaling event-time joins beyond a single replica.**
+- **Ordering guarantees** — sequence numbers exist but are used only for deduplication; there is
+  no reorder buffer.
+- **Cycles and iterative dataflow.**
+
+---
+
+## Decisions already made
+
+Recorded because they shape everything above and shouldn't be relitigated:
+
+- Windows hold history the node has already acknowledged, never messages still in flight.
+- `None` will not become a drop signal — that would silently change the behaviour of every
+  existing flow. A separate skip value is used instead.
+- Emitting several outputs is done by calling an emit method, not by turning processing into a
+  generator, which would break the rebuild-in-a-worker contract every node depends on.
+- Control parents are named, not passed as node references, so a graph still serializes.
+- Markers are delivered with the same guarantees as data, not fire-and-forget.
+- Per-key windows require a partition key, enforced when the graph is built.

--- a/docs/source/first-steps/getting-started-with-videoflow.rst
+++ b/docs/source/first-steps/getting-started-with-videoflow.rst
@@ -108,5 +108,31 @@ tuple. Videoflow matches the two inputs that originated from the same upstream
 event before delivering them to the join — you do not have to synchronize anything
 yourself.
 
+Complete example solutions
+--------------------------
+
+The `solutions/ <https://github.com/videoflow/videoflow/tree/master/solutions>`_
+directory holds three complete, deployable applications built from core nodes
+only — no models, no footage, no extra dependencies:
+
+``toy_calculator``
+    A BATCH diamond over a stream of integers: fan-out, a trace join, competing
+    replicas, stateful aggregation and a two-parent consumer. The smallest
+    complete solution, and the best one to read first.
+
+``toy_router``
+    Partitioned parallelism — ``partition_by`` pinning each key to one replica,
+    an ``async def process`` node, and an idempotent sink.
+
+``toy_fusion``
+    A REALTIME flow fusing independent producers by event time, with tolerance,
+    lateness timeout, quorum and collect windows.
+
+Each runs in seconds and writes a self-checking artifact saying whether the
+distributed run computed the right answer::
+
+    cd solutions/toy_calculator
+    videoflow run-local toy_calculator.py
+
 Next, read :doc:`../distributed/distributed-execution` to understand how the same
 graph runs locally versus on Kubernetes.

--- a/solutions/README.md
+++ b/solutions/README.md
@@ -1,0 +1,47 @@
+# Solutions
+
+Complete, deployable videoflow applications built from **core nodes only** — no
+models, no footage, no `videoflow_contrib` packages, and no dependencies beyond
+the videoflow base image. Each is a real solution in the full sense (`build_flow`
+factory, config template, prep hook, Dockerfile) that `videoflow deploy` will
+take to a Kubernetes cluster in one command.
+
+They exist to be read and to be run. A full deploy costs seconds of compute
+rather than the minutes an ML solution costs, which makes them the right first
+target when you want to prove the *framework* path — config Q&A, prep hook,
+in-image compile, manifests, broker, workers, teardown — before spending real
+time on a model.
+
+| Solution | Flow type | What it demonstrates |
+|---|---|---|
+| [toy_calculator](toy_calculator) | BATCH | A diamond over a stream of integers: fan-out, a trace join re-aligning two branches, competing replicas, stateful aggregation, a two-parent consumer, a `metadata=True` consumer, and a prep hook. The smallest complete solution — **read this one first**. |
+| [toy_router](toy_router) | BATCH | Partitioned parallelism: `partition_by` routing that pins each key to one replica, `ctx.set_partition_key`, an `async def process` node, replica identity, and an idempotent sink. |
+| [toy_fusion](toy_fusion) | REALTIME | Independent producers fused by **event time**: time-mode `JoinPolicy` with tolerance, lateness timeout, quorum and a collect window; unbounded live sources. |
+
+## Running one
+
+```bash
+docker compose up -d nats redis      # a broker to talk to (from the repo root)
+cd solutions/toy_calculator
+videoflow run-local toy_calculator.py
+```
+
+`run-local` generates `config.yaml` from `config.template.yaml` the first time
+(it asks a few questions), runs `prepare.py`, and spawns one worker subprocess
+per node. To deploy the same graph to a cluster instead, swap in
+`videoflow deploy toy_calculator.py`. Each solution's README documents every
+config key.
+
+## They are also the end-to-end test suite
+
+`tests/integration/test_toy_solutions.py` runs all three on every CI build and
+asserts their self-checking artifacts — `report.json`'s `matches_expected`,
+`counts.json`'s `matches_expected` and `sticky`, `fusion_summary.json`'s
+complete moments. A green run means the distributed path computed the right
+answer, not merely that nothing crashed.
+
+So these solutions carry two responsibilities at once. If you change a graph, a
+node or a config key, update the solution's `README.md`, its
+`config.example.yaml` and `config.template.yaml`, **and** the matching config
+dict in the test. And keep the streams short — the whole suite should stay
+around 25 seconds.

--- a/solutions/toy_calculator/Dockerfile
+++ b/solutions/toy_calculator/Dockerfile
@@ -1,0 +1,28 @@
+# videoflow :: solutions/toy_calculator — BATCH diamond over integers — CPU.
+#
+# The smallest solution image: no dependencies beyond videoflow-base itself. The
+# graph wires core nodes to the glue nodes in toy_calculator_nodes.py, which
+# workers reconstruct as `toy_calculator_nodes.<Class>`. Python 3.12.
+#
+# Build from the videoflow repo ROOT (for consistency with the other solutions;
+# nothing outside this directory is copied):
+#   docker build -f solutions/toy_calculator/Dockerfile -t videoflow-toy-calculator:latest .
+#
+# Normally you don't build this by hand — `videoflow deploy toy_calculator.py`
+# builds it, loads it into the cluster, and runs the flow. See README.md.
+ARG BASE_IMAGE=videoflow-base:py3.12
+FROM ${BASE_IMAGE}
+
+WORKDIR /app
+
+# No dependency install: requirements.txt is deliberately empty (see the comment
+# in it) — the base image already carries everything these nodes need.
+
+# The solution modules: the graph, the importable glue nodes the worker
+# reconstructs, the config loader, and the prep hook deploy runs.
+COPY solutions/toy_calculator/toy_calculator.py \
+     solutions/toy_calculator/toy_calculator_nodes.py \
+     solutions/toy_calculator/common.py \
+     solutions/toy_calculator/prepare.py ./
+
+# ENTRYPOINT ["python", "-m", "videoflow.worker"] is inherited from videoflow-base.

--- a/solutions/toy_calculator/README.md
+++ b/solutions/toy_calculator/README.md
@@ -1,0 +1,114 @@
+# Toy Calculator
+
+The smallest deployable videoflow solution: a BATCH diamond over a stream of
+integers, built from core nodes plus five tiny glue nodes. No models, no video,
+no dependencies beyond the videoflow base image — a full deploy costs seconds
+of compute, which makes this the right first target when you want to prove the
+*framework* path (config Q&A, prep hook, in-image compile, manifests, broker,
+workers, teardown) before spending minutes on an ML solution.
+
+It is also a readable map of videoflow's graph machinery:
+
+```
+numbers ─┬─> square (N replicas) ─┬─> pair ─┬─> stats ─┬─> report   (also joins pair)
+         └─> delay ───────────────┘         │          └─> printer
+                                            ├─> pairs-log
+                                            └─> (pair is report's other parent)
+square ──(metadata)──> proctimes
+```
+
+| Mechanism | Where it shows up |
+|---|---|
+| Fan-out | `numbers` feeds both branches; `pair` feeds three sinks |
+| Competing replicas (`nb_tasks`) | `square` runs `square.workers` replicas, finishing out of order |
+| Trace join + `JoinPolicy` | `pair` re-aligns the branches by lineage; policy from `join.*` config |
+| Stateful aggregation (`OneTaskProcessorNode`) | `stats` keeps running totals |
+| Consumer with two parents | `report` consumes `(pair, stats)` grouped by trace |
+| `open()`/`close()` lifecycle | `report` writes its file in `close()`; `proctimes` opens/closes its handle |
+| `metadata=True` consumer | `proctimes` receives per-message timing instead of payloads |
+| Prep hook | `prepare.py` bakes the closed-form ground truth into `work_dir` |
+
+## The self-checking artifact
+
+`prepare.py` writes `expected.json` (closed-form `count`/`sum`/`sum_squares`/
+`min`/`max` for the configured range). After end-of-stream, the `report`
+consumer writes `report.json` including `"matches_expected": true|false|null`.
+`true` means every integer crossed every edge exactly once and the join
+re-aligned all of them — the whole point of a BATCH flow. Verify a run with:
+
+```bash
+python -c "import json; r=json.load(open('out/report.json')); print(r); assert r['matches_expected']"
+```
+
+## Deploying to Kubernetes (one command)
+
+With a local cluster (k3s / kind / minikube / Docker Desktop) plus docker and
+kubectl, the host needs only the videoflow CLI:
+
+```bash
+pip install -e ".[deploy]"          # from the repo root
+cd solutions/toy_calculator
+videoflow deploy toy_calculator.py
+```
+
+That asks three questions, writes `config.yaml`, builds and loads the image,
+runs `prepare.py` in-image, provisions a dev NATS+Redis, runs the flow to
+completion, and tears everything down. `report.json` lands in `out/` on this
+machine. CPU only — there is no `gpu.Dockerfile` here on purpose.
+
+## Run locally (no cluster)
+
+```bash
+cd solutions/toy_calculator
+videoflow run-local toy_calculator.py
+```
+
+The graph needs only core videoflow — no `videoflow_contrib` packages, no
+models, no footage. Or drive it manually against your own broker:
+
+```bash
+docker compose up -d nats redis            # NATS :4222, Redis :6379
+
+cd solutions/toy_calculator
+cp config.example.yaml config.yaml
+python prepare.py --config config.yaml
+python toy_calculator.py --config config.yaml
+```
+
+## In the test suite
+
+`tests/integration/test_toy_solutions.py` runs this solution end to end on
+every CI build: it copies the solution to a temp directory, writes a small fast
+config, drives it with `videoflow run-local`, and asserts
+`report.json["matches_expected"]` is `true`. Changing the graph, the nodes or
+the config keys means updating that test — it is the regression gate that keeps
+the framework path working, so keep the solution runnable with a short stream.
+
+## Configuration reference (`config.yaml`)
+
+`videoflow deploy` asks for the starred (★) values; everything else has a
+sensible default. Relative paths resolve against the config file's directory.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `work_dir` | `./out` | Where every artifact lands (`expected.json`, `report.json`, `pairs.jsonl`, `proctimes.jsonl`). Mounted read-write into the pods at the same absolute path. |
+| `start_value` | `1` | First integer of the stream. |
+| `end_value` ★ | `200` | Last integer (inclusive); the report's `count` must equal `end_value - start_value + 1`. |
+| `producer_fps` | `50` | Producer pacing, messages/second (`<= 0` = unpaced). |
+| `delay_fps` | `40` | Pacing of the identity branch. Slightly slower than the producer, so the two arms of the diamond drift apart and the join visibly re-aligns them. |
+| `flow_type` | `batch` | Keep `batch`: it is loss-free, so `matches_expected` must be `true`. `realtime` works too but may legitimately drop under pressure. |
+| `square.workers` ★ | `2` | Competing replicas for the stateless square stage. |
+| `join.missing` ★ | `wait` | `JoinPolicy` for the pair join: `wait` (batch default), or `drop`/`error` with `join.timeout_s` to see incomplete groups acked away or dead-lettered. |
+| `join.timeout_s` | `null` | How long an incomplete join group waits before `join.missing` applies (`null` = forever). |
+| `join.max_pending` | `100000` | Cap on buffered incomplete groups. Must exceed `(producer_fps - delay_fps) * stream duration`, since the unpaced square branch runs that far ahead — the policy's own 256 default would silently evict pairs. |
+
+## Files
+
+| File | Role |
+|---|---|
+| `toy_calculator.py` | Graph module: `build_flow(cfg=None)` plus a local `main()`. |
+| `toy_calculator_nodes.py` | The five glue nodes in their own importable module, so distributed workers can reconstruct them by class path. |
+| `common.py` | `load_config()` — resolves `work_dir` against the config file's directory. |
+| `config.example.yaml` / `config.template.yaml` | Documented example / the template deploy asks questions from. |
+| `prepare.py` | Idempotent ground-truth writer, run by deploy before compiling. |
+| `Dockerfile` | CPU image on `videoflow-base:py3.12`, built from the repo root. No GPU variant — nothing here wants one. |

--- a/solutions/toy_calculator/common.py
+++ b/solutions/toy_calculator/common.py
@@ -1,0 +1,97 @@
+'''
+Shared config loading for the toy-calculator solution.
+
+The config is a small YAML file (see config.example.yaml). ``load_config``
+returns a Config with ``work_dir`` resolved to an absolute location **relative
+to the config file's directory**, not the process cwd — so the prep script, a
+local run, and ``videoflow deploy`` (which compiles the graph from any cwd) all
+bake the same paths into the node parameters.
+'''
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import yaml
+
+MISSING_POLICIES = ('wait', 'drop', 'error')
+
+
+@dataclass
+class Config:
+    path: str
+    work_dir: str
+    start_value: int
+    end_value: int
+    producer_fps: float
+    delay_fps: float
+    workers: int
+    join_timeout_s: float | None
+    join_missing: str
+    join_max_pending: int
+    flow_type: str
+
+    def work_path(self, *parts: str) -> str:
+        p = os.path.join(self.work_dir, *parts)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        return p
+
+    def expected_path(self) -> str:
+        '''Where prepare.py writes the closed-form ground truth.'''
+        return self.work_path('expected.json')
+
+    def report_path(self) -> str:
+        '''The self-checking success artifact the report consumer writes in close().'''
+        return self.work_path('report.json')
+
+
+def load_config(path: str) -> Config:
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    cfg_dir = os.path.dirname(os.path.abspath(path))
+
+    work_dir = os.path.abspath(os.path.join(cfg_dir, raw.get('work_dir', './out')))
+    os.makedirs(work_dir, exist_ok=True)
+
+    start_value = int(raw.get('start_value', 1))
+    end_value = int(raw.get('end_value', 200))
+    if end_value < start_value:
+        raise ValueError(f'end_value ({end_value}) must be >= start_value ({start_value}); '
+                         f'fix them in {os.path.abspath(path)}')
+
+    square = raw.get('square') or {}
+    workers = int(square.get('workers', 2))
+    if workers < 1:
+        raise ValueError(f'square.workers must be >= 1, got {workers}')
+
+    join = raw.get('join') or {}
+    join_missing = str(join.get('missing', 'wait')).lower()
+    if join_missing not in MISSING_POLICIES:
+        raise ValueError(f"join.missing must be one of {MISSING_POLICIES}, got {join_missing!r}")
+    raw_timeout = join.get('timeout_s')
+    join_timeout_s = float(raw_timeout) if raw_timeout is not None else None
+    # The unpaced square branch runs ahead of the paced delay branch, so up to
+    # (producer_fps - delay_fps) * runtime join groups sit incomplete at once.
+    # The default policy cap (256) would evict — i.e. silently drop — beyond
+    # that, so the toy raises it well past any configurable stream length.
+    join_max_pending = int(join.get('max_pending', 100000))
+    if join_max_pending < 1:
+        raise ValueError(f'join.max_pending must be >= 1, got {join_max_pending}')
+
+    flow_type = str(raw.get('flow_type', 'batch')).lower()
+    if flow_type not in ('batch', 'realtime'):
+        raise ValueError(f"flow_type must be 'batch' or 'realtime', got {flow_type!r}")
+
+    return Config(
+        path=os.path.abspath(path),
+        work_dir=work_dir,
+        start_value=start_value,
+        end_value=end_value,
+        producer_fps=float(raw.get('producer_fps', 50.0)),
+        delay_fps=float(raw.get('delay_fps', 40.0)),
+        workers=workers,
+        join_timeout_s=join_timeout_s,
+        join_missing=join_missing,
+        join_max_pending=join_max_pending,
+        flow_type=flow_type,
+    )

--- a/solutions/toy_calculator/config.example.yaml
+++ b/solutions/toy_calculator/config.example.yaml
@@ -1,0 +1,45 @@
+# Toy-calculator configuration, fully documented. Copy to config.yaml and edit
+# (or let `videoflow deploy` / `videoflow run-local` generate one from
+# config.template.yaml by asking questions). Relative paths resolve against the
+# directory this file lives in.
+
+# Where every artifact lands: expected.json (from prepare.py), report.json,
+# pairs.jsonl, proctimes.jsonl. Mounted into the worker pods at the same
+# absolute path, so results appear on your machine.
+work_dir: ./out
+
+# The integer stream: start_value..end_value inclusive. The stream length is
+# what the final report's `count` must equal.
+start_value: 1
+end_value: 200
+
+# Producer pacing in messages per second (<= 0 = as fast as possible).
+producer_fps: 50
+
+# Pacing of the identity branch (<= 0 = no delay). A slightly slower branch
+# creates real skew between the two arms of the diamond, so the trace join is
+# visibly re-aligning messages rather than passing them through.
+delay_fps: 40
+
+# batch = loss-free, backpressured, runs to completion — what this toy is for.
+# realtime also works, but under pressure it may drop messages, and then the
+# report's matches_expected can legitimately be false.
+flow_type: batch
+
+square:
+  # Competing replicas for the stateless square stage. > 1 makes the branch
+  # finish out of order — the disorder the pair join re-aligns.
+  workers: 2
+
+join:
+  # JoinPolicy for the pair join. With `wait` (the batch default) a group waits
+  # indefinitely for its other half. `drop`/`error` + a timeout_s show what
+  # happens to incomplete groups instead: drop acks them away, error sends them
+  # to redelivery and eventually the DLQ.
+  timeout_s: null
+  missing: wait
+  # Cap on buffered incomplete groups (the oldest is evicted beyond it). The
+  # unpaced square branch runs ahead of the paced delay branch, so this must
+  # exceed (producer_fps - delay_fps) * stream duration or pairs get dropped —
+  # the policy's own default of 256 is deliberately overridden here.
+  max_pending: 100000

--- a/solutions/toy_calculator/config.template.yaml
+++ b/solutions/toy_calculator/config.template.yaml
@@ -1,0 +1,38 @@
+# Toy-calculator config template. `videoflow deploy toy_calculator.py` reads this
+# when no config.yaml exists: it asks the x-questions below, writes config.yaml,
+# and hostPath-mounts the x-mounts paths into the prep container and the worker
+# pods. See config.example.yaml for what every knob means.
+work_dir: ./out
+start_value: 1
+end_value: 200
+producer_fps: 50
+delay_fps: 40
+flow_type: batch
+square:
+  workers: 2
+join:
+  timeout_s: null
+  missing: wait
+  max_pending: 100000
+
+# Inputs `videoflow deploy` asks for when generating config.yaml.
+x-questions:
+  - key: end_value
+    prompt: 'Last integer to produce (the stream is start_value..end_value)'
+    type: int
+    default: 200
+  - key: square.workers
+    prompt: 'Competing replicas for the square stage'
+    type: int
+    default: 2
+  - key: join.missing
+    prompt: 'What the pair join does with a group that never completes'
+    type: choice
+    choices: [wait, drop, error]
+    default: wait
+
+# The work dir must be visible inside prep containers and worker pods at the same
+# absolute path: it holds expected.json (written by prepare.py, read by the report
+# consumer) and receives report.json, pairs.jsonl and proctimes.jsonl.
+x-mounts:
+  - '{work_dir}'

--- a/solutions/toy_calculator/prepare.py
+++ b/solutions/toy_calculator/prepare.py
@@ -1,0 +1,65 @@
+'''
+Prep for the toy-calculator solution: bake the ground truth.
+
+Writes ``expected.json`` — the closed-form final statistics for the configured
+integer range — into ``work_dir``, so the flow's ``report`` consumer can record
+whether the distributed run reproduced them. That turns ``report.json`` into a
+self-checking artifact: ``"matches_expected": true`` means every message made
+it through every edge exactly once.
+
+`videoflow deploy toy_calculator.py` runs this automatically inside the
+solution image before compiling; it can also be run by hand:
+
+    python prepare.py --config config.yaml [--force]
+
+Idempotent: skips the write when ``expected.json`` already holds the values
+for the configured range.
+'''
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from common import Config, load_config
+
+
+def expected_stats(cfg: Config) -> dict:
+    '''The final RunningStats snapshot for the range, in closed form (same key layout).'''
+    a, b = cfg.start_value, cfg.end_value
+    count = b - a + 1
+
+    def sum_squares_to(m: int) -> int:
+        return m * (m + 1) * (2 * m + 1) // 6 if m > 0 else 0
+
+    return {
+        'count': count,
+        'sum': (a + b) * count // 2,
+        'sum_squares': sum_squares_to(b) - sum_squares_to(a - 1),
+        'min': a,
+        'max': b,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Write the expected final statistics into work_dir.')
+    ap.add_argument('--config', default='config.yaml')
+    ap.add_argument('--force', action='store_true', help='rewrite even if already up to date')
+    args = ap.parse_args()
+    cfg = load_config(args.config)
+
+    expected = expected_stats(cfg)
+    path = cfg.expected_path()
+    if not args.force and os.path.exists(path):
+        with open(path) as f:
+            if json.load(f) == expected:
+                print(f'==> {path} already matches the configured range; skipping (--force to rewrite)')
+                return
+    with open(path, 'w') as f:
+        json.dump(expected, f, indent=2)
+    print(f'==> wrote {path} for range {cfg.start_value}..{cfg.end_value}')
+    print('Prep complete.')
+
+
+if __name__ == '__main__':
+    main()

--- a/solutions/toy_calculator/requirements.txt
+++ b/solutions/toy_calculator/requirements.txt
@@ -1,0 +1,4 @@
+# No dependencies beyond the videoflow base image: the glue nodes are pure
+# stdlib, and PyYAML (for common.py) ships in videoflow-base. The file exists
+# so the solution keeps the standard layout; add real dependencies here (and
+# re-enable the install step in the Dockerfile) if the toy ever grows some.

--- a/solutions/toy_calculator/toy_calculator.py
+++ b/solutions/toy_calculator/toy_calculator.py
@@ -1,0 +1,100 @@
+'''
+Toy calculator — the smallest BATCH videoflow application.
+
+Built only from core nodes plus five tiny glue nodes: no models, no video, no
+dependencies beyond the videoflow base image. It exists so the whole deploy
+pipeline (config Q&A, prep hook, in-image compile, manifests, broker, workers)
+can be exercised in seconds, and as a readable reference for the graph
+machinery itself:
+
+    numbers ─┬─> square (N replicas) ─┬─> pair ─┬─> stats ─┬─> report
+             └─> delay ───────────────┘         │          ├─> printer
+                                                ├──────────┴─> report (2nd parent)
+                                                └─> pairs-log
+    square ──(metadata)──> proctimes
+
+- **fan-out**: ``numbers`` feeds two branches; ``pair`` feeds three sinks.
+- **a trace join**: ``pair`` re-aligns the branches by lineage even though the
+  replicated ``square`` branch finishes out of order (its policy comes from
+  ``join.missing`` / ``join.timeout_s`` in the config).
+- **replication**: ``square`` runs ``square.workers`` competing replicas.
+- **stateful aggregation**: ``stats`` is a ``OneTaskProcessorNode``.
+- **consumer join + lifecycle**: ``report`` consumes (pair, stats) and writes
+  the self-checking ``report.json`` from ``close()``.
+- **a metadata consumer**: ``proctimes`` sees per-message timing, not payloads.
+
+``prepare.py`` bakes the closed-form ground truth into ``work_dir`` so
+``report.json`` can say whether the distributed run got the right answer.
+
+Deploy to Kubernetes (config Q&A, image build, broker, run and teardown in one
+command — see README.md):
+
+    videoflow deploy toy_calculator.py
+
+Local run, all workers as subprocesses on this machine:
+
+    python toy_calculator.py --config config.yaml
+
+The glue nodes live in ``toy_calculator_nodes.py`` (a real importable module)
+so distributed workers can reconstruct them by class path (the local engine
+puts this directory on each worker's PYTHONPATH automatically).
+'''
+from __future__ import annotations
+
+import argparse
+import os
+
+from common import load_config
+from toy_calculator_nodes import (
+    PairJoiner,
+    ProcTimeMonitor,
+    ReportWriter,
+    RunningStats,
+    SquareProcessor,
+)
+
+from videoflow.consumers import CommandlineConsumer, FileAppenderConsumer
+from videoflow.core import Flow
+from videoflow.core.policies import JoinPolicy
+from videoflow.processors import IdentityProcessor
+from videoflow.producers import IntProducer
+
+
+def build_flow(cfg=None):
+    if cfg is None:
+        # Module-dir-relative so `videoflow deploy` works from any cwd.
+        cfg = load_config(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml'))
+
+    numbers = IntProducer(cfg.start_value, cfg.end_value, fps=cfg.producer_fps, name='numbers')
+    square = SquareProcessor(nb_tasks=cfg.workers, name='square')(numbers)
+    delay = IdentityProcessor(fps=cfg.delay_fps, name='delay')(numbers)
+    pair = PairJoiner(
+        join_policy=JoinPolicy(timeout_seconds=cfg.join_timeout_s, missing=cfg.join_missing,
+                               max_pending=cfg.join_max_pending),
+        name='pair')(delay, square)
+    stats = RunningStats(name='stats')(pair)
+    report = ReportWriter(cfg.report_path(), cfg.expected_path(), name='report')(pair, stats)
+    printer = CommandlineConsumer(name='printer')(stats)
+    pairs_log = FileAppenderConsumer(cfg.work_path('pairs.jsonl'), name='pairs-log')(pair)
+    proctimes = ProcTimeMonitor(cfg.work_path('proctimes.jsonl'), name='proctimes')(square)
+    return Flow([report, printer, pairs_log, proctimes], flow_type=cfg.flow_type)
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Run the toy-calculator flow locally (every node a subprocess).')
+    ap.add_argument('--config', default='config.yaml')
+    args = ap.parse_args()
+    cfg = load_config(args.config)
+    from videoflow.engines.local import LocalProcessEngine
+    flow = build_flow(cfg)
+    engine = LocalProcessEngine(blob_redis_url=os.environ.get('VIDEOFLOW_BLOB_REDIS_URL'))
+    flow.run(engine)
+    flow.join()
+    if engine.failures():
+        engine.report_failures()
+        raise SystemExit(1)
+    print(f'Wrote {cfg.report_path()}')
+
+
+if __name__ == '__main__':
+    main()

--- a/solutions/toy_calculator/toy_calculator_nodes.py
+++ b/solutions/toy_calculator/toy_calculator_nodes.py
@@ -1,0 +1,145 @@
+'''
+Glue nodes for the toy-calculator solution.
+
+These live in their own importable module (not in the graph module) because
+distributed workers reconstruct each node from its class path — recorded as
+``toy_calculator_nodes.<Class>`` — and importing the graph module in a worker
+would re-run graph-level code. Every constructor argument is stored as
+``self._<name>`` so the node round-trips through ``get_params()`` into the
+worker unchanged.
+
+The nodes are deliberately trivial: this solution exists to exercise
+videoflow's graph machinery (fan-out, trace joins, competing replicas,
+stateful aggregation, the consumer lifecycle and metadata consumers), not to
+compute anything interesting.
+'''
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, TextIO
+
+from videoflow.core.node import ConsumerNode, OneTaskProcessorNode, ProcessorNode
+
+
+class SquareProcessor(ProcessorNode):
+    '''
+    Squares each integer. Stateless, so it is safe to replicate: with
+    ``nb_tasks > 1`` the replicas compete for messages and finish out of
+    order — which is exactly the disorder the downstream trace join re-aligns.
+    '''
+
+    def process(self, n: int) -> int:
+        return n * n
+
+
+class PairJoiner(ProcessorNode):
+    '''
+    Two-parent join node: receives the original integer (via the paced delay
+    branch) and its square (via the replicated branch) for the *same*
+    originating message, grouped by trace id no matter how far the two branches
+    drifted apart. Emits one dict per joined pair.
+    '''
+
+    # One positional argument per parent, so the signature can't match the
+    # single-input base method.
+    def process(self, n: int, square: int) -> dict:  # type: ignore[override]
+        return {'n': n, 'square': square}
+
+
+class RunningStats(OneTaskProcessorNode):
+    '''
+    Keeps running statistics over every pair seen. The state across messages is
+    why this is a ``OneTaskProcessorNode``: replicating it would split the
+    totals across workers and no replica would hold the true numbers.
+    '''
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._stats: dict = {'count': 0, 'sum': 0, 'sum_squares': 0, 'min': None, 'max': None}
+        super().__init__(**kwargs)
+
+    def process(self, pair: dict) -> dict:
+        s = self._stats
+        n = pair['n']
+        s['count'] += 1
+        s['sum'] += n
+        s['sum_squares'] += pair['square']
+        s['min'] = n if s['min'] is None else min(s['min'], n)
+        s['max'] = n if s['max'] is None else max(s['max'], n)
+        return dict(s)
+
+
+class ReportWriter(ConsumerNode):
+    '''
+    Two-parent *consumer* join: consumes each pair together with the stats
+    snapshot that very pair produced (they share a trace id, so the join groups
+    them). Keeps the latest snapshot and writes ``report.json`` from
+    ``close()`` — the lifecycle hook that runs in the worker after
+    end-of-stream. If ``prepare.py`` left an ``expected.json`` next to it, the
+    report also records whether the final stats match it, so a single file
+    answers "did the whole distributed run compute the right thing".
+
+    - Arguments:
+        - report_path: where to write the final report (inside ``work_dir``, \
+            which is mounted at the same absolute path in the worker pod).
+        - expected_path: the ground-truth file ``prepare.py`` wrote, or None \
+            to skip the comparison.
+    '''
+
+    def __init__(self, report_path: str, expected_path: str | None = None, **kwargs: Any) -> None:
+        self._report_path = report_path
+        self._expected_path = expected_path
+        self._latest: dict | None = None
+        self._pairs_seen = 0
+        super().__init__(**kwargs)
+
+    # One positional argument per parent, so the signature can't match the
+    # single-input base method.
+    def consume(self, pair: dict, stats: dict) -> None:  # type: ignore[override]
+        self._pairs_seen += 1
+        self._latest = stats
+
+    def close(self) -> None:
+        report: dict = {
+            'pairs_seen': self._pairs_seen,
+            'final_stats': self._latest,
+            'matches_expected': None,
+        }
+        if self._expected_path and os.path.exists(self._expected_path):
+            with open(self._expected_path) as f:
+                report['matches_expected'] = self._latest == json.load(f)
+        tmp = self._report_path + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(report, f, indent=2)
+        os.replace(tmp, self._report_path)
+
+
+class ProcTimeMonitor(ConsumerNode):
+    '''
+    A ``metadata=True`` consumer: instead of its parent's payload it receives
+    the per-message metadata the framework publishes alongside it (``proctime``
+    and ``actual_proctime``). Appends one JSON line per message — a toy
+    throughput monitor. The file handle follows the node lifecycle: opened in
+    ``open()``, released in ``close()``.
+    '''
+
+    def __init__(self, out_path: str, **kwargs: Any) -> None:
+        self._out_path = out_path
+        # metadata is fixed to True below; pop it so reconstruction via
+        # get_params() doesn't pass it twice.
+        kwargs.pop('metadata', None)
+        self._fh: TextIO | None = None
+        super().__init__(metadata=True, **kwargs)
+
+    def open(self) -> None:
+        self._fh = open(self._out_path, 'a')
+
+    def consume(self, meta: dict) -> None:
+        assert self._fh is not None
+        self._fh.write(json.dumps(meta) + '\n')
+        self._fh.flush()
+
+    def close(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None

--- a/solutions/toy_fusion/Dockerfile
+++ b/solutions/toy_fusion/Dockerfile
@@ -1,0 +1,28 @@
+# videoflow :: solutions/toy_fusion — REALTIME time-aligned fusion — CPU.
+#
+# A minimal solution image: no dependencies beyond videoflow-base itself. The
+# graph wires the simulated sources and fusion nodes in toy_fusion_nodes.py,
+# which workers reconstruct as `toy_fusion_nodes.<Class>`. Python 3.12.
+#
+# Build from the videoflow repo ROOT (for consistency with the other solutions;
+# nothing outside this directory is copied):
+#   docker build -f solutions/toy_fusion/Dockerfile -t videoflow-toy-fusion:latest .
+#
+# Normally you don't build this by hand — `videoflow deploy toy_fusion.py`
+# builds it, loads it into the cluster, and runs the flow. See README.md.
+ARG BASE_IMAGE=videoflow-base:py3.12
+FROM ${BASE_IMAGE}
+
+WORKDIR /app
+
+# No dependency install: requirements.txt is deliberately empty (see the comment
+# in it) — the base image already carries everything these nodes need.
+
+# The solution modules: the graph, the importable glue nodes the worker
+# reconstructs, and the config loader. There is no prepare.py — this solution
+# needs nothing prepared.
+COPY solutions/toy_fusion/toy_fusion.py \
+     solutions/toy_fusion/toy_fusion_nodes.py \
+     solutions/toy_fusion/common.py ./
+
+# ENTRYPOINT ["python", "-m", "videoflow.worker"] is inherited from videoflow-base.

--- a/solutions/toy_fusion/README.md
+++ b/solutions/toy_fusion/README.md
@@ -1,0 +1,120 @@
+# Toy Fusion
+
+The REALTIME videoflow example: N simulated fixed-rate cameras plus a
+simulated 100 Hz IMU, fused by **event time**. No models, no video, no
+dependencies beyond the videoflow base image — the point is the part of the
+framework the other solutions don't touch: unbounded live sources, the
+drop-when-full REALTIME broker policy, and a time-mode `JoinPolicy` with
+tolerance, lateness timeout, quorum and a collect window.
+
+```
+cam0 (10 fps, +0ms phase) ──┐
+cam1 (10 fps, +3ms phase) ──┼─> fuse (time join) ──> live-report
+imu  (100 Hz)  ─────────────┘
+```
+
+The cameras are *independent producers* — they share no upstream lineage, so a
+trace join could never group them. Each stamps its messages with
+`ctx.set_event_timestamp`; the fusion node groups frames whose timestamps fall
+within `fusion.tolerance_ms`, waits at most `fusion.timeout_s` for stragglers,
+emits with at least `fusion.quorum` cameras (missing ones arrive as `None`),
+and receives every IMU sample within `fusion.sensor_window_ms` of the moment
+as a list. `ctx.input_info` gives the fusion node each input's exact event
+time, which is how the reported `spread_ms` is measured.
+
+| Mechanism | Where it shows up |
+|---|---|
+| REALTIME flow type | `flow_type: realtime` — drop rather than stall |
+| Unbounded producers (`is_finite=False`) | `duration_s: 0` — Deployments on k8s, run ends at teardown |
+| Time-mode join (`tolerance_ms`) | `fuse` groups frames by capture time |
+| Quorum emission | a moment emits with ≥ `quorum` cameras; gaps arrive as `None` |
+| Collect parent | the IMU never gates a moment; samples arrive as a list |
+| `ctx.set_event_timestamp` / `ctx.input_info` | producers stamp, fusion measures |
+| Live sink | `live-report` atomically rewrites `latest.json` each moment |
+| Optional prep hook | there is deliberately **no** `prepare.py` here |
+
+## What "it works" looks like
+
+REALTIME success is observed, not awaited:
+
+- **While running**: `work_dir/latest.json` is atomically rewritten on every
+  fused moment — watch its `moment` counter and mtime advance
+  (`watch -n1 cat out/latest.json`).
+- **After a bounded run** (`duration_s > 0`) or a stop: `fusion_summary.json`
+  reports total moments and the complete/quorum split.
+
+```bash
+python -c "import json; s=json.load(open('out/fusion_summary.json')); print(s); assert s['moments'] > 0"
+```
+
+## Deploying to Kubernetes (one command)
+
+```bash
+pip install -e ".[deploy]"          # from the repo root
+cd solutions/toy_fusion
+videoflow deploy toy_fusion.py
+```
+
+With the default `duration_s: 0` this is a genuine REALTIME deploy: `deploy`
+applies the manifests, checks schedulability for ~30 seconds and returns while
+the flow keeps running. Watch `latest.json` advance, then end the run with the
+`videoflow teardown` command deploy prints. CPU only — there is no
+`gpu.Dockerfile` here on purpose.
+
+## Run locally (no cluster)
+
+```bash
+cd solutions/toy_fusion
+videoflow run-local toy_fusion.py
+```
+
+The graph needs only core videoflow — no `videoflow_contrib` packages, no
+models, no footage. For a smoke run that ends on its own, set `duration_s: 20`
+in `config.yaml`; with `0` the flow runs until Ctrl-C. Manual variant:
+
+```bash
+docker compose up -d nats redis            # NATS :4222, Redis :6379
+
+cd solutions/toy_fusion
+cp config.example.yaml config.yaml      # set duration_s: 20 for a bounded run
+python toy_fusion.py --config config.yaml
+```
+
+## In the test suite
+
+`tests/integration/test_toy_solutions.py` runs this solution end to end on
+every CI build: it copies the solution to a temp directory, writes a config
+with a small `duration_s` so the unbounded sources become a bounded run, drives
+it with `videoflow run-local`, and asserts `fusion_summary.json` reports
+complete moments carrying IMU samples. This is the only integration test that
+exercises the REALTIME path with independent producers, so keep the solution
+runnable with a short `duration_s`.
+
+## Configuration reference (`config.yaml`)
+
+`videoflow deploy` asks for the starred (★) values; everything else has a
+sensible default. Relative paths resolve against the config file's directory.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `work_dir` | `./out` | Where `latest.json` and `fusion_summary.json` land. Mounted read-write into the pods at the same absolute path. |
+| `cameras` ★ | `2` | Number of simulated cameras — and of camera producer pods. |
+| `camera_fps` | `10` | Frame rate of every camera. |
+| `phase_step_ms` | `3.0` | Camera i starts `i * phase_step_ms` late, so the cameras are genuinely unsynchronized. Keep well under `fusion.tolerance_ms`. |
+| `sensor_hz` | `100` | IMU sample rate (the collect parent). |
+| `duration_s` ★ | `0` | `0` = sources never stop (true realtime; end with teardown/Ctrl-C). `> 0` bounds a smoke run so it drains on its own. |
+| `flow_type` | `realtime` | Drop-when-full. `batch` also works for bounded runs and then nothing may be dropped. |
+| `fusion.tolerance_ms` | `15` | Frames within this window are one moment. Keep under one frame period and above `phase_step_ms * (cameras - 1)`. |
+| `fusion.timeout_s` | `0.25` | Lateness bound before a moment emits with whoever arrived. |
+| `fusion.quorum` | `1` | Minimum cameras for a timed-out moment to emit; missing cameras arrive as `None`. Between 1 and `cameras`. |
+| `fusion.sensor_window_ms` | `40` | IMU samples this close to the moment are delivered as a list. |
+
+## Files
+
+| File | Role |
+|---|---|
+| `toy_fusion.py` | Graph module: `build_flow(cfg=None)` plus a local `main()`. |
+| `toy_fusion_nodes.py` | Simulated sources, fusion and sink in their own importable module, so distributed workers can reconstruct them by class path. |
+| `common.py` | `load_config()` — resolves `work_dir` against the config file's directory. |
+| `config.example.yaml` / `config.template.yaml` | Documented example / the template deploy asks questions from. |
+| `Dockerfile` | CPU image on `videoflow-base:py3.12`, built from the repo root. No GPU variant, and no `prepare.py` — both are optional and this solution needs neither. |

--- a/solutions/toy_fusion/common.py
+++ b/solutions/toy_fusion/common.py
@@ -1,0 +1,89 @@
+'''
+Shared config loading for the toy-fusion solution.
+
+The config is a small YAML file (see config.example.yaml). ``load_config``
+returns a Config with ``work_dir`` resolved to an absolute location **relative
+to the config file's directory**, not the process cwd — so a local run and
+``videoflow deploy`` (which compiles the graph from any cwd) bake the same
+paths into the node parameters.
+
+``duration_s`` of 0 (or null) means the simulated sources never stop — the
+true REALTIME shape, where producers deploy as long-running Deployments and the
+run ends only at teardown. A positive value bounds the run, which is how a
+smoke test finishes on its own.
+'''
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import yaml
+
+
+@dataclass
+class Config:
+    path: str
+    work_dir: str
+    cameras: int
+    camera_fps: float
+    phase_step_ms: float
+    sensor_hz: float
+    duration_s: float | None
+    tolerance_ms: float
+    timeout_s: float
+    quorum: int
+    sensor_window_ms: float
+    flow_type: str
+
+    def latest_path(self) -> str:
+        '''The continuously-rewritten live artifact; its advancing mtime is the REALTIME health check.'''
+        return self.work_path('latest.json')
+
+    def summary_path(self) -> str:
+        '''Written from close() — only reachable on a bounded (duration_s > 0) or stopped run.'''
+        return self.work_path('fusion_summary.json')
+
+    def work_path(self, *parts: str) -> str:
+        p = os.path.join(self.work_dir, *parts)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        return p
+
+
+def load_config(path: str) -> Config:
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    cfg_dir = os.path.dirname(os.path.abspath(path))
+
+    work_dir = os.path.abspath(os.path.join(cfg_dir, raw.get('work_dir', './out')))
+    os.makedirs(work_dir, exist_ok=True)
+
+    cameras = int(raw.get('cameras', 2))
+    if cameras < 1:
+        raise ValueError(f'cameras must be >= 1, got {cameras}')
+
+    raw_duration = raw.get('duration_s', 0)
+    duration_s = float(raw_duration) if raw_duration else None
+
+    fusion = raw.get('fusion') or {}
+    quorum = int(fusion.get('quorum', max(1, cameras - 1)))
+    if not 1 <= quorum <= cameras:
+        raise ValueError(f'fusion.quorum must be between 1 and cameras ({cameras}), got {quorum}')
+
+    flow_type = str(raw.get('flow_type', 'realtime')).lower()
+    if flow_type not in ('batch', 'realtime'):
+        raise ValueError(f"flow_type must be 'batch' or 'realtime', got {flow_type!r}")
+
+    return Config(
+        path=os.path.abspath(path),
+        work_dir=work_dir,
+        cameras=cameras,
+        camera_fps=float(raw.get('camera_fps', 10.0)),
+        phase_step_ms=float(raw.get('phase_step_ms', 3.0)),
+        sensor_hz=float(raw.get('sensor_hz', 100.0)),
+        duration_s=duration_s,
+        tolerance_ms=float(fusion.get('tolerance_ms', 15.0)),
+        timeout_s=float(fusion.get('timeout_s', 0.25)),
+        quorum=quorum,
+        sensor_window_ms=float(fusion.get('sensor_window_ms', 40.0)),
+        flow_type=flow_type,
+    )

--- a/solutions/toy_fusion/config.example.yaml
+++ b/solutions/toy_fusion/config.example.yaml
@@ -1,0 +1,49 @@
+# Toy-fusion configuration, fully documented. Copy to config.yaml and edit (or
+# let `videoflow deploy` / `videoflow run-local` generate one from
+# config.template.yaml by asking questions). Relative paths resolve against the
+# directory this file lives in.
+
+# Where the artifacts land: latest.json (atomically rewritten on every fused
+# moment) and fusion_summary.json (written when a bounded run drains). Mounted
+# into the worker pods at the same absolute path.
+work_dir: ./out
+
+# How many simulated cameras to run. Each is its own producer node, so this is
+# also the number of camera workers/pods.
+cameras: 2
+
+# Frames per second of every simulated camera.
+camera_fps: 10
+
+# Per-camera clock offset in milliseconds (camera i starts i * phase_step_ms
+# late). Keeps the cameras genuinely unsynchronized so the fusion tolerance is
+# doing real work; keep it well under the tolerance.
+phase_step_ms: 3.0
+
+# Sample rate of the simulated IMU — the fast, collect-joined parent.
+sensor_hz: 100
+
+# 0 (or null) = the sources never stop: the true realtime shape, where the
+# producers deploy as long-running Deployments and only teardown ends the run.
+# A positive number of seconds bounds the run so it finishes on its own —
+# right for local smoke tests.
+duration_s: 0
+
+# realtime = drop-when-full: a straggler must not stall live output. batch also
+# works (bounded runs only) and then nothing may be dropped.
+flow_type: realtime
+
+fusion:
+  # Camera frames whose event timestamps differ by at most this many
+  # milliseconds count as the same moment. Keep it under one frame period
+  # (100ms at 10 fps) and above phase_step_ms * (cameras - 1).
+  tolerance_ms: 15
+  # Lateness bound: how long after a moment's first frame a straggler may
+  # still arrive before the group is emitted with whoever is present.
+  timeout_s: 0.25
+  # Minimum cameras for a timed-out moment to still be emitted (missing
+  # cameras reach process() as None). Must be between 1 and cameras.
+  quorum: 1
+  # IMU samples within this many milliseconds of the moment are delivered as a
+  # list. The IMU never gates a moment and doesn't count toward the quorum.
+  sensor_window_ms: 40

--- a/solutions/toy_fusion/config.template.yaml
+++ b/solutions/toy_fusion/config.template.yaml
@@ -1,0 +1,34 @@
+# Toy-fusion config template. `videoflow deploy toy_fusion.py` reads this when
+# no config.yaml exists: it asks the x-questions below, writes config.yaml, and
+# hostPath-mounts the x-mounts paths into the worker pods. See
+# config.example.yaml for what every knob means.
+work_dir: ./out
+cameras: 2
+camera_fps: 10
+phase_step_ms: 3.0
+sensor_hz: 100
+duration_s: 0
+flow_type: realtime
+fusion:
+  tolerance_ms: 15
+  timeout_s: 0.25
+  quorum: 1
+  sensor_window_ms: 40
+
+# Inputs `videoflow deploy` asks for when generating config.yaml.
+x-questions:
+  - key: cameras
+    prompt: 'Number of simulated cameras'
+    type: int
+    default: 2
+  - key: duration_s
+    prompt: 'Seconds to run (0 = run forever, the realtime default; teardown ends the run)'
+    type: float
+    default: 0
+
+# The work dir must be visible inside the worker pods at the same absolute
+# path: latest.json is rewritten there on every fused moment (its advancing
+# mtime is how you watch a realtime run), and fusion_summary.json lands there
+# when a bounded run drains.
+x-mounts:
+  - '{work_dir}'

--- a/solutions/toy_fusion/requirements.txt
+++ b/solutions/toy_fusion/requirements.txt
@@ -1,0 +1,4 @@
+# No dependencies beyond the videoflow base image: the glue nodes are pure
+# stdlib, and PyYAML (for common.py) ships in videoflow-base. The file exists
+# so the solution keeps the standard layout; add real dependencies here (and
+# re-enable the install step in the Dockerfile) if the toy ever grows some.

--- a/solutions/toy_fusion/toy_fusion.py
+++ b/solutions/toy_fusion/toy_fusion.py
@@ -1,0 +1,102 @@
+'''
+Toy fusion — the REALTIME videoflow example.
+
+Simulated, independent live sources — N fixed-rate cameras plus a high-rate
+IMU — fused by **event time**. The producers share no upstream lineage, so a
+trace join could never group them; instead each stamps its messages with
+``ctx.set_event_timestamp`` and the fusion node's ``JoinPolicy(mode='time')``
+groups inputs whose timestamps fall within a tolerance:
+
+    cam0 (10 fps) ──┐
+    cam1 (10 fps) ──┼─> fuse (time join, quorum, collect) ──> live-report
+    imu (100 Hz) ───┘        │
+                             └── every fused moment atomically rewrites
+                                 work_dir/latest.json
+
+- **REALTIME flow type**: under pressure the broker drops rather than blocks —
+  a straggler camera frame must not stall live output.
+- **unbounded producers** (``is_finite=False`` when ``duration_s`` is 0): on
+  Kubernetes they deploy as long-running Deployments; the run ends at teardown.
+- **time-mode join knobs**: ``tolerance_ms`` (same-moment window), ``timeout_s``
+  (lateness bound), ``quorum`` (emit with at least k cameras, missing ones
+  passed as ``None``), and ``collect`` (the IMU never gates a group; its
+  samples near the moment arrive as a list).
+- **``ctx.input_info``**: the fusion node reads each input's exact event time
+  to measure the spread, without any payload changes.
+
+There is deliberately no ``prepare.py``: the prep hook is optional, and this
+solution needs nothing prepared.
+
+Deploy to Kubernetes (config Q&A, image build, broker — see README.md):
+
+    videoflow deploy toy_fusion.py
+
+Local smoke run (bounded by duration_s, all workers as subprocesses):
+
+    python toy_fusion.py --config config.yaml
+
+The glue nodes live in ``toy_fusion_nodes.py`` (a real importable module) so
+distributed workers can reconstruct them by class path (the local engine puts
+this directory on each worker's PYTHONPATH automatically).
+'''
+from __future__ import annotations
+
+import argparse
+import os
+
+from common import load_config
+from toy_fusion_nodes import LiveStateWriter, MomentFusion, SimCameraProducer, SimSensorProducer
+
+from videoflow.core import Flow
+from videoflow.core.policies import JoinPolicy
+
+
+def build_flow(cfg=None):
+    if cfg is None:
+        # Module-dir-relative so `videoflow deploy` works from any cwd.
+        cfg = load_config(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml'))
+
+    cameras = [
+        SimCameraProducer(fps=cfg.camera_fps, phase_ms=i * cfg.phase_step_ms,
+                          duration_s=cfg.duration_s, name=f'cam{i}')
+        for i in range(cfg.cameras)
+    ]
+    sensor = SimSensorProducer(hz=cfg.sensor_hz, duration_s=cfg.duration_s, name='imu')
+    fuse = MomentFusion(
+        camera_names=[camera.name for camera in cameras],
+        sensor_name=sensor.name,
+        join_policy=JoinPolicy(
+            mode='time',
+            tolerance_ms=cfg.tolerance_ms,
+            timeout_seconds=cfg.timeout_s,
+            quorum=cfg.quorum,
+            collect={sensor.name: cfg.sensor_window_ms},
+        ),
+        name='fuse')(*cameras, sensor)
+    live = LiveStateWriter(cfg.latest_path(), cfg.summary_path(), name='live-report')(fuse)
+    return Flow([live], flow_type=cfg.flow_type)
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Run the toy-fusion flow locally (every node a subprocess).')
+    ap.add_argument('--config', default='config.yaml')
+    args = ap.parse_args()
+    cfg = load_config(args.config)
+    if cfg.duration_s is None:
+        print('duration_s is 0: the sources never stop — Ctrl-C to end the run.')
+    from videoflow.engines.local import LocalProcessEngine
+    flow = build_flow(cfg)
+    engine = LocalProcessEngine(blob_redis_url=os.environ.get('VIDEOFLOW_BLOB_REDIS_URL'))
+    flow.run(engine)
+    try:
+        flow.join()
+    except KeyboardInterrupt:
+        flow.stop()
+    if engine.failures():
+        engine.report_failures()
+        raise SystemExit(1)
+    print(f'Live artifact: {cfg.latest_path()}; summary: {cfg.summary_path()}')
+
+
+if __name__ == '__main__':
+    main()

--- a/solutions/toy_fusion/toy_fusion_nodes.py
+++ b/solutions/toy_fusion/toy_fusion_nodes.py
@@ -1,0 +1,215 @@
+'''
+Glue nodes for the toy-fusion solution.
+
+These live in their own importable module (not in the graph module) because
+distributed workers reconstruct each node from its class path — recorded as
+``toy_fusion_nodes.<Class>`` — and importing the graph module in a worker would
+re-run graph-level code. Every constructor argument is stored as
+``self._<name>`` so the node round-trips through ``get_params()`` unchanged.
+
+The simulated sources stand in for real hardware (fixed-rate cameras and a
+high-rate IMU) with none of the I/O: what this solution exercises is the
+**time-aligned join** — independent producers with no shared lineage, grouped
+by the event timestamps they stamp on their own messages.
+'''
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from typing import Any
+
+from videoflow.core.context import RuntimeContext
+from videoflow.core.node import ConsumerNode, OneTaskProcessorNode, ProducerNode
+
+
+def _aligned_start() -> float:
+    '''
+    The producer's tick-grid origin: the next-but-one whole epoch second.
+
+    Every simulated source anchors its timeline here rather than at its own
+    ``open()`` instant, because the workers open seconds apart (subprocess or
+    pod startup) and a time-mode join can only group event timestamps that
+    actually coincide. Aligning to whole epoch seconds puts every producer on
+    one shared grid — the simulation stand-in for the synchronized capture
+    clocks (PTP, genlock) that real multi-camera rigs rely on. A late-starting
+    source simply joins the grid at a later second, and until then the others'
+    moments emit at quorum — exactly what happens when a real camera comes
+    online late.
+    '''
+    return float(math.ceil(time.time()) + 1)
+
+
+class SimCameraProducer(ProducerNode):
+    '''
+    Simulated fixed-rate camera. Emits one small "frame summary" dict per tick
+    and stamps each message with the tick's ideal capture time via
+    ``ctx.set_event_timestamp`` — the value time-mode joins group on. A
+    per-camera phase offset of a few milliseconds keeps the cameras genuinely
+    unsynchronized, so the fusion tolerance is doing real work.
+
+    With ``duration_s`` unset it never stops (``is_finite=False`` — a live
+    source, deployed as a long-running Deployment on Kubernetes). With it set,
+    ``next()`` raises ``StopIteration`` after that many seconds of stream time,
+    which is what lets a smoke run finish on its own.
+    '''
+
+    def __init__(self, fps: float = 10.0, phase_ms: float = 0.0,
+                 duration_s: float | None = None, **kwargs: Any) -> None:
+        self._fps = fps
+        self._phase_ms = phase_ms
+        self._duration_s = duration_s
+        self._t0: float | None = None
+        self._n = 0
+        # is_finite is derived from duration_s; pop it so reconstruction via
+        # get_params() doesn't pass it twice.
+        kwargs.pop('is_finite', None)
+        super().__init__(is_finite=duration_s is not None, **kwargs)
+
+    def open(self) -> None:
+        self._t0 = _aligned_start()
+
+    def next(self, ctx: RuntimeContext | None = None) -> dict:
+        if self._duration_s is not None and self._n / self._fps >= self._duration_s:
+            raise StopIteration()
+        assert self._t0 is not None
+        t = self._t0 + self._phase_ms / 1000.0 + self._n / self._fps
+        # Pace to wall clock so several producers interleave in real time.
+        now = time.time()
+        if t > now:
+            time.sleep(t - now)
+        self._n += 1
+        if ctx is not None:
+            ctx.set_event_timestamp(t)
+        return {
+            'frame_idx': self._n - 1,
+            'brightness': round(50.0 + 40.0 * math.sin(self._n / 20.0), 3),
+        }
+
+
+class SimSensorProducer(ProducerNode):
+    '''
+    Simulated high-rate sensor (an IMU running an order of magnitude faster
+    than the cameras). It is meant to be a *collect* parent of the fusion node:
+    it never gates a join group; instead every sample near a group's moment is
+    delivered to ``process()`` as a list.
+    '''
+
+    def __init__(self, hz: float = 100.0, duration_s: float | None = None, **kwargs: Any) -> None:
+        self._hz = hz
+        self._duration_s = duration_s
+        self._t0: float | None = None
+        self._n = 0
+        # is_finite is derived from duration_s; pop it so reconstruction via
+        # get_params() doesn't pass it twice.
+        kwargs.pop('is_finite', None)
+        super().__init__(is_finite=duration_s is not None, **kwargs)
+
+    def open(self) -> None:
+        self._t0 = _aligned_start()
+
+    def next(self, ctx: RuntimeContext | None = None) -> dict:
+        if self._duration_s is not None and self._n / self._hz >= self._duration_s:
+            raise StopIteration()
+        assert self._t0 is not None
+        t = self._t0 + self._n / self._hz
+        now = time.time()
+        if t > now:
+            time.sleep(t - now)
+        self._n += 1
+        if ctx is not None:
+            ctx.set_event_timestamp(t)
+        return {'sample': self._n - 1, 'accel': round(math.sin(self._n / 10.0), 4)}
+
+
+class MomentFusion(OneTaskProcessorNode):
+    '''
+    Fuses one synchronized "moment": the camera summaries whose event times
+    fall within the join tolerance, plus every sensor sample the collect window
+    gathered around them. Quorum emissions pass missing cameras as ``None``;
+    ``ctx.input_info`` supplies each input's exact event time, which is how the
+    spread is measured without changing any payload.
+
+    Stateful (it numbers the moments), hence a ``OneTaskProcessorNode`` — and a
+    multi-parent join must be single-replica anyway unless it is partitioned.
+
+    - Arguments:
+        - camera_names: the camera parents' node names, in the same order the \
+            cameras are wired into this node.
+        - sensor_name: the collect parent's node name.
+    '''
+
+    def __init__(self, camera_names: list[str], sensor_name: str, **kwargs: Any) -> None:
+        self._camera_names = list(camera_names)
+        self._sensor_name = sensor_name
+        self._moment = 0
+        super().__init__(**kwargs)
+
+    # One positional argument per parent (cameras first, then the sensor's
+    # collected list), so the signature can't match the single-input base method.
+    def process(self, *inputs: Any, ctx: RuntimeContext | None = None) -> dict:  # type: ignore[override]
+        cameras = list(inputs[:len(self._camera_names)])
+        samples = inputs[len(self._camera_names)] or []
+        info = ctx.input_info if ctx is not None else None
+
+        views = [name for name, frame in zip(self._camera_names, cameras) if frame is not None]
+        times = []
+        if info is not None:
+            times = [info[name]['event_ts'] for name in views
+                     if info.get(name) is not None and info[name]['event_ts'] is not None]
+        brightness = [frame['brightness'] for frame in cameras if frame is not None]
+        accels = [sample['accel'] for sample in samples]
+
+        self._moment += 1
+        return {
+            'moment': self._moment,
+            'views': len(views),
+            'expected_views': len(self._camera_names),
+            'spread_ms': round((max(times) - min(times)) * 1000.0, 3) if len(times) > 1 else 0.0,
+            'brightness_mean': round(sum(brightness) / len(brightness), 3) if brightness else None,
+            'sensor_samples': len(accels),
+            'accel_mean': round(sum(accels) / len(accels), 4) if accels else None,
+        }
+
+
+class LiveStateWriter(ConsumerNode):
+    '''
+    A REALTIME-shaped sink: atomically rewrites ``latest.json`` on every fused
+    moment, so an operator (or a verifier) can watch the file's content and
+    mtime advance while the flow runs. ``close()`` — reached only when the
+    sources are bounded or the flow is stopped — writes a run summary.
+    '''
+
+    def __init__(self, latest_path: str, summary_path: str, **kwargs: Any) -> None:
+        self._latest_path = latest_path
+        self._summary_path = summary_path
+        self._moments = 0
+        self._complete = 0
+        self._started: float | None = None
+        super().__init__(**kwargs)
+
+    def open(self) -> None:
+        self._started = time.time()
+
+    def consume(self, moment: dict) -> None:
+        self._moments += 1
+        if moment['views'] == moment['expected_views']:
+            self._complete += 1
+        self._write(self._latest_path, {**moment, 'updated_unix': round(time.time(), 3)})
+
+    def close(self) -> None:
+        elapsed = time.time() - self._started if self._started is not None else None
+        self._write(self._summary_path, {
+            'moments': self._moments,
+            'complete_moments': self._complete,
+            'quorum_moments': self._moments - self._complete,
+            'elapsed_s': round(elapsed, 3) if elapsed is not None else None,
+        })
+
+    def _write(self, path: str, payload: dict) -> None:
+        # Atomic replace: a reader polling the file never sees a half-written JSON.
+        tmp = path + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(payload, f, indent=2)
+        os.replace(tmp, path)

--- a/solutions/toy_router/Dockerfile
+++ b/solutions/toy_router/Dockerfile
@@ -1,0 +1,28 @@
+# videoflow :: solutions/toy_router — partitioned per-key counting — CPU.
+#
+# A minimal solution image: no dependencies beyond videoflow-base itself. The
+# graph wires the nodes in toy_router_nodes.py, which workers reconstruct as
+# `toy_router_nodes.<Class>`. Python 3.12.
+#
+# Build from the videoflow repo ROOT (for consistency with the other solutions;
+# nothing outside this directory is copied):
+#   docker build -f solutions/toy_router/Dockerfile -t videoflow-toy-router:latest .
+#
+# Normally you don't build this by hand — `videoflow deploy toy_router.py`
+# builds it, loads it into the cluster, and runs the flow. See README.md.
+ARG BASE_IMAGE=videoflow-base:py3.12
+FROM ${BASE_IMAGE}
+
+WORKDIR /app
+
+# No dependency install: requirements.txt is deliberately empty (see the comment
+# in it) — the base image already carries everything these nodes need.
+
+# The solution modules: the graph, the importable glue nodes the worker
+# reconstructs, the config loader, and the prep hook deploy runs.
+COPY solutions/toy_router/toy_router.py \
+     solutions/toy_router/toy_router_nodes.py \
+     solutions/toy_router/common.py \
+     solutions/toy_router/prepare.py ./
+
+# ENTRYPOINT ["python", "-m", "videoflow.worker"] is inherited from videoflow-base.

--- a/solutions/toy_router/README.md
+++ b/solutions/toy_router/README.md
@@ -1,0 +1,114 @@
+# Toy Router
+
+Partitioned parallelism, end to end: a deterministic stream of sensor events
+flows through an async enrichment stage into a **replicated, stateful**
+per-sensor counter — the combination that is only correct because the
+counter's input edge is partitioned by key. No models, no video, no
+dependencies beyond the videoflow base image.
+
+```
+events ──> enrich (async, stamps the key) ──> count (N partitioned replicas) ──> ledger
+```
+
+| Mechanism | Where it shows up |
+|---|---|
+| Partitioned routing (`partition_by` + `nb_tasks`) | `count` — each sensor id hashes to exactly one replica |
+| `ctx.set_partition_key` | `enrich` stamps the sensor id onto its output's metadata (`_partition_key`); keys don't propagate on their own, so the node feeding the partitioned edge stamps them |
+| `partition_by: trace_id` alternative | flip the config: totals stay right, but sensors spread across replicas — visible in `counts.json` |
+| `async def process` | `enrich` awaits its simulated lookup on the task-owned event loop |
+| Replica identity (`ctx.replica_id`, `ctx.logger`) | `count` tags every update with the replica that made it |
+| Idempotent consumer | `ledger` is built with `idempotent=true` — effects dedup across redelivery when Redis is present |
+| Indexed-Job workloads | on Kubernetes, a partitioned BATCH stage runs as an Indexed Job (one completion index per replica) |
+| Prep hook | `prepare.py` walks the producer's PRNG and bakes expected totals |
+
+## The self-checking artifact
+
+`prepare.py` writes `expected_counts.json` (per-sensor totals for the seeded
+stream). After end-of-stream the `ledger` consumer writes `counts.json`:
+
+- `totals` — per-sensor counts, summed across replicas' shares;
+- `replicas` — which counter replicas touched each sensor;
+- `sticky` — `true` iff every sensor was owned by exactly one replica (what
+  `_partition_key` routing guarantees and `trace_id` routing doesn't);
+- `matches_expected` — whether `totals` equals the baked ground truth.
+
+```bash
+python -c "import json; c=json.load(open('out/counts.json')); print(c); assert c['matches_expected'] and c['sticky']"
+```
+
+(Drop the `c['sticky']` assertion when running with `partition_by: trace_id` —
+spreading keys across replicas is that mode's expected behaviour.)
+
+## Deploying to Kubernetes (one command)
+
+```bash
+pip install -e ".[deploy]"          # from the repo root
+cd solutions/toy_router
+videoflow deploy toy_router.py
+```
+
+That asks three questions, writes `config.yaml`, builds and loads the image,
+runs `prepare.py` in-image, provisions a dev NATS+Redis, runs the flow to
+completion, and tears everything down. `counts.json` lands in `out/` on this
+machine. CPU only — there is no `gpu.Dockerfile` here on purpose.
+
+## Run locally (no cluster)
+
+```bash
+cd solutions/toy_router
+videoflow run-local toy_router.py
+```
+
+The graph needs only core videoflow — no `videoflow_contrib` packages, no
+models, no footage. Or drive it manually against your own broker:
+
+```bash
+docker compose up -d nats redis            # NATS :4222, Redis :6379
+export VIDEOFLOW_BLOB_REDIS_URL=redis://localhost:6379/0   # gives the idempotent sink its store
+
+cd solutions/toy_router
+cp config.example.yaml config.yaml
+python prepare.py --config config.yaml
+python toy_router.py --config config.yaml
+```
+
+## In the test suite
+
+`tests/integration/test_toy_solutions.py` runs this solution end to end on
+every CI build: it copies the solution to a temp directory, writes a small fast
+config, drives it with `videoflow run-local`, and asserts `counts.json` reports
+both `matches_expected` and `sticky` — the two claims partitioned routing makes.
+It is the regression gate for `partition_by`, so keep the solution runnable with
+a short stream.
+
+## Configuration reference (`config.yaml`)
+
+`videoflow deploy` asks for the starred (★) values; everything else has a
+sensible default. Relative paths resolve against the config file's directory.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `work_dir` | `./out` | Where every artifact lands (`expected_counts.json`, `ledger.jsonl`, `counts.json`). Mounted read-write into the pods at the same absolute path. |
+| `seed` | `7` | PRNG seed shared by the producer and `prepare.py`. |
+| `events` ★ | `300` | Stream length; `sum(totals.values())` must equal it. |
+| `sensors` | `6` | Distinct keys in the stream. |
+| `rate_fps` | `100` | Producer pacing, messages/second (`<= 0` = unpaced). |
+| `idempotent_sink` | `true` | Construct the ledger with `idempotent=True` (dedup across redelivery when Redis is available). |
+| `enrich.threshold` | `50.0` | `high`/`low` bucket boundary. |
+| `enrich.lookup_ms` | `1.0` | Simulated async lookup latency per message. |
+| `counter.partitions` ★ | `3` | Replicas of the stateful counter stage. |
+| `counter.partition_by` ★ | `_partition_key` | `_partition_key` = sticky per sensor; `trace_id` = per lineage (sensors spread across replicas; `sticky` goes `false`). |
+
+The flow type is fixed to `batch`: the count verification depends on the
+loss-free retention policy, and a realtime run may legitimately drop.
+
+## Files
+
+| File | Role |
+|---|---|
+| `toy_router.py` | Graph module: `build_flow(cfg=None)` plus a local `main()`. |
+| `toy_router_nodes.py` | `iter_events` plus the four nodes in their own importable module, so distributed workers can reconstruct them by class path. |
+| `common.py` | `load_config()` — resolves `work_dir` against the config file's directory. |
+| `config.example.yaml` / `config.template.yaml` | Documented example / the template deploy asks questions from. |
+| `prepare.py` | Idempotent ground-truth writer, run by deploy before compiling. |
+| `Dockerfile` | CPU image on `videoflow-base:py3.12`, built from the repo root. No GPU variant — nothing here wants one. |

--- a/solutions/toy_router/common.py
+++ b/solutions/toy_router/common.py
@@ -1,0 +1,89 @@
+'''
+Shared config loading for the toy-router solution.
+
+The config is a small YAML file (see config.example.yaml). ``load_config``
+returns a Config with ``work_dir`` resolved to an absolute location **relative
+to the config file's directory**, not the process cwd — so the prep script, a
+local run, and ``videoflow deploy`` (which compiles the graph from any cwd) all
+bake the same paths into the node parameters.
+'''
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import yaml
+
+PARTITION_MODES = ('_partition_key', 'trace_id')
+
+
+@dataclass
+class Config:
+    path: str
+    work_dir: str
+    seed: int
+    events: int
+    sensors: int
+    rate_fps: float
+    threshold: float
+    lookup_ms: float
+    partitions: int
+    partition_by: str
+    idempotent_sink: bool
+
+    def work_path(self, *parts: str) -> str:
+        p = os.path.join(self.work_dir, *parts)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        return p
+
+    def expected_path(self) -> str:
+        '''Where prepare.py writes the expected per-sensor totals.'''
+        return self.work_path('expected_counts.json')
+
+    def ledger_path(self) -> str:
+        return self.work_path('ledger.jsonl')
+
+    def counts_path(self) -> str:
+        '''The self-checking success artifact the ledger consumer writes in close().'''
+        return self.work_path('counts.json')
+
+
+def load_config(path: str) -> Config:
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+    cfg_dir = os.path.dirname(os.path.abspath(path))
+
+    work_dir = os.path.abspath(os.path.join(cfg_dir, raw.get('work_dir', './out')))
+    os.makedirs(work_dir, exist_ok=True)
+
+    events = int(raw.get('events', 300))
+    if events < 1:
+        raise ValueError(f'events must be >= 1, got {events}')
+    sensors = int(raw.get('sensors', 6))
+    if sensors < 1:
+        raise ValueError(f'sensors must be >= 1, got {sensors}')
+
+    counter = raw.get('counter') or {}
+    partitions = int(counter.get('partitions', 3))
+    if partitions < 1:
+        raise ValueError(f'counter.partitions must be >= 1, got {partitions}')
+    partition_by = str(counter.get('partition_by', '_partition_key'))
+    if partition_by not in PARTITION_MODES:
+        raise ValueError(f'counter.partition_by must be one of {PARTITION_MODES}, '
+                         f'got {partition_by!r}')
+
+    enrich = raw.get('enrich') or {}
+
+    return Config(
+        path=os.path.abspath(path),
+        work_dir=work_dir,
+        seed=int(raw.get('seed', 7)),
+        events=events,
+        sensors=sensors,
+        rate_fps=float(raw.get('rate_fps', 100.0)),
+        threshold=float(enrich.get('threshold', 50.0)),
+        lookup_ms=float(enrich.get('lookup_ms', 1.0)),
+        partitions=partitions,
+        partition_by=partition_by,
+        idempotent_sink=bool(raw.get('idempotent_sink', True)),
+    )

--- a/solutions/toy_router/config.example.yaml
+++ b/solutions/toy_router/config.example.yaml
@@ -1,0 +1,41 @@
+# Toy-router configuration, fully documented. Copy to config.yaml and edit (or
+# let `videoflow deploy` / `videoflow run-local` generate one from
+# config.template.yaml by asking questions). Relative paths resolve against the
+# directory this file lives in.
+
+# Where every artifact lands: expected_counts.json (from prepare.py),
+# ledger.jsonl and counts.json. Mounted into the worker pods at the same
+# absolute path, so results appear on your machine.
+work_dir: ./out
+
+# The deterministic event stream: `events` messages spread over `sensors`
+# distinct keys, generated from `seed`. prepare.py walks the same PRNG, which
+# is how the expected totals exist before the flow runs.
+seed: 7
+events: 300
+sensors: 6
+
+# Producer pacing in messages per second (<= 0 = as fast as possible).
+rate_fps: 100
+
+# Construct the ledger consumer with idempotent=True: when the flow has a
+# Redis idempotency store (run-local and deploy provision one), its side
+# effects are deduplicated across broker redelivery.
+idempotent_sink: true
+
+enrich:
+  # Events with value >= threshold are bucketed 'high', the rest 'low'.
+  threshold: 50.0
+  # Simulated latency of the async lookup, per message.
+  lookup_ms: 1.0
+
+counter:
+  # Replicas of the stateful counter stage. Safe to replicate ONLY because the
+  # input is partitioned: hash(key) % partitions pins each key to one replica.
+  partitions: 3
+  # _partition_key routes by the sensor id the enricher stamps (sticky per
+  # sensor — counts.json shows exactly one replica per sensor). trace_id
+  # routes by lineage instead: totals stay correct (the ledger sums each
+  # replica's share) but one sensor's events spread across replicas, and
+  # counts.json shows it.
+  partition_by: _partition_key

--- a/solutions/toy_router/config.template.yaml
+++ b/solutions/toy_router/config.template.yaml
@@ -1,0 +1,38 @@
+# Toy-router config template. `videoflow deploy toy_router.py` reads this when
+# no config.yaml exists: it asks the x-questions below, writes config.yaml, and
+# hostPath-mounts the x-mounts paths into the prep container and the worker
+# pods. See config.example.yaml for what every knob means.
+work_dir: ./out
+seed: 7
+events: 300
+sensors: 6
+rate_fps: 100
+idempotent_sink: true
+enrich:
+  threshold: 50.0
+  lookup_ms: 1.0
+counter:
+  partitions: 3
+  partition_by: _partition_key
+
+# Inputs `videoflow deploy` asks for when generating config.yaml.
+x-questions:
+  - key: events
+    prompt: 'Number of events to produce'
+    type: int
+    default: 300
+  - key: counter.partitions
+    prompt: 'Partitioned replicas for the counter stage'
+    type: int
+    default: 3
+  - key: counter.partition_by
+    prompt: 'Routing key (_partition_key = sticky per sensor, trace_id = per lineage)'
+    type: choice
+    choices: [_partition_key, trace_id]
+    default: _partition_key
+
+# The work dir must be visible inside prep containers and worker pods at the
+# same absolute path: it holds expected_counts.json (written by prepare.py,
+# read by the ledger consumer) and receives ledger.jsonl and counts.json.
+x-mounts:
+  - '{work_dir}'

--- a/solutions/toy_router/prepare.py
+++ b/solutions/toy_router/prepare.py
@@ -1,0 +1,56 @@
+'''
+Prep for the toy-router solution: bake the ground truth.
+
+Walks the same seeded PRNG as the flow's producer (``iter_events`` in
+``toy_router_nodes.py``) and writes the expected per-sensor totals to
+``expected_counts.json`` in ``work_dir`` — so the flow's ``ledger`` consumer
+can record whether the distributed, partitioned run counted every event
+exactly once (``counts.json`` → ``"matches_expected": true``).
+
+`videoflow deploy toy_router.py` runs this automatically inside the solution
+image before compiling; it can also be run by hand:
+
+    python prepare.py --config config.yaml [--force]
+
+Idempotent: skips the write when ``expected_counts.json`` already holds the
+totals for the configured stream.
+'''
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from common import Config, load_config
+from toy_router_nodes import iter_events
+
+
+def expected_counts(cfg: Config) -> dict:
+    totals: dict = {}
+    for event in iter_events(cfg.seed, cfg.events, cfg.sensors):
+        totals[event['sensor']] = totals.get(event['sensor'], 0) + 1
+    return dict(sorted(totals.items()))
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Write the expected per-sensor totals into work_dir.')
+    ap.add_argument('--config', default='config.yaml')
+    ap.add_argument('--force', action='store_true', help='rewrite even if already up to date')
+    args = ap.parse_args()
+    cfg = load_config(args.config)
+
+    expected = expected_counts(cfg)
+    path = cfg.expected_path()
+    if not args.force and os.path.exists(path):
+        with open(path) as f:
+            if json.load(f) == expected:
+                print(f'==> {path} already matches the configured stream; skipping (--force to rewrite)')
+                return
+    with open(path, 'w') as f:
+        json.dump(expected, f, indent=2)
+    print(f'==> wrote {path} for {cfg.events} events over {cfg.sensors} sensors (seed {cfg.seed})')
+    print('Prep complete.')
+
+
+if __name__ == '__main__':
+    main()

--- a/solutions/toy_router/requirements.txt
+++ b/solutions/toy_router/requirements.txt
@@ -1,0 +1,4 @@
+# No dependencies beyond the videoflow base image: the glue nodes are pure
+# stdlib, and PyYAML (for common.py) ships in videoflow-base. The file exists
+# so the solution keeps the standard layout; add real dependencies here (and
+# re-enable the install step in the Dockerfile) if the toy ever grows some.

--- a/solutions/toy_router/toy_router.py
+++ b/solutions/toy_router/toy_router.py
@@ -1,0 +1,89 @@
+'''
+Toy router — partitioned parallelism, end to end.
+
+A deterministic stream of sensor events flows through an async enrichment
+stage into a **replicated, stateful** per-sensor counter — the combination
+that is only correct because the counter's input is partitioned by key:
+
+    events ──> enrich (async, stamps the key) ──> count (N partitioned replicas) ──> ledger
+
+- **partitioned routing**: ``count`` runs ``counter.partitions`` replicas with
+  ``partition_by='_partition_key'``; every message with the same sensor id
+  lands on the same replica (``hash(key) % replicas``), which is what makes
+  per-key state safe to replicate. On Kubernetes a partitioned BATCH stage
+  runs as an Indexed Job — each completion index is a replica id.
+- **the business key on the wire**: ``enrich`` calls ``ctx.set_partition_key``
+  so the sensor id rides the message metadata into the partitioned edge.
+  Setting ``counter.partition_by: trace_id`` routes by lineage instead — the
+  totals stay right (the ledger sums each replica's share) but ``counts.json``
+  then shows several replicas per sensor: stickiness, made visible.
+- **an async node**: ``enrich`` is ``async def process`` — videoflow awaits it
+  on a task-owned event loop.
+- **an idempotent sink**: ``ledger`` is constructed with
+  ``idempotent=idempotent_sink``, so its side effects are deduplicated across
+  broker redelivery when a Redis idempotency store is available.
+
+``prepare.py`` walks the same seeded PRNG as the producer and bakes the
+expected per-sensor totals, so ``counts.json`` can say whether the distributed
+run counted correctly (``"matches_expected": true``).
+
+Deploy to Kubernetes (config Q&A, image build, broker, run and teardown in one
+command — see README.md):
+
+    videoflow deploy toy_router.py
+
+Local run, all workers as subprocesses on this machine:
+
+    python toy_router.py --config config.yaml
+
+The glue nodes live in ``toy_router_nodes.py`` (a real importable module) so
+distributed workers can reconstruct them by class path (the local engine puts
+this directory on each worker's PYTHONPATH automatically).
+'''
+from __future__ import annotations
+
+import argparse
+import os
+
+from common import load_config
+from toy_router_nodes import AsyncEnricher, EventProducer, KeyedCounter, LedgerWriter
+
+from videoflow.core import Flow
+
+
+def build_flow(cfg=None):
+    if cfg is None:
+        # Module-dir-relative so `videoflow deploy` works from any cwd.
+        cfg = load_config(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yaml'))
+
+    events = EventProducer(cfg.seed, cfg.events, cfg.sensors, rate_fps=cfg.rate_fps,
+                           name='events')
+    enrich = AsyncEnricher(threshold=cfg.threshold, lookup_ms=cfg.lookup_ms,
+                           name='enrich')(events)
+    count = KeyedCounter(nb_tasks=cfg.partitions, partition_by=cfg.partition_by,
+                         name='count')(enrich)
+    ledger = LedgerWriter(cfg.ledger_path(), cfg.counts_path(), cfg.expected_path(),
+                          idempotent=cfg.idempotent_sink, name='ledger')(count)
+    # BATCH on purpose: the count verification needs the loss-free retention
+    # policy — under realtime the broker may legitimately drop.
+    return Flow([ledger], flow_type='batch')
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Run the toy-router flow locally (every node a subprocess).')
+    ap.add_argument('--config', default='config.yaml')
+    args = ap.parse_args()
+    cfg = load_config(args.config)
+    from videoflow.engines.local import LocalProcessEngine
+    flow = build_flow(cfg)
+    engine = LocalProcessEngine(blob_redis_url=os.environ.get('VIDEOFLOW_BLOB_REDIS_URL'))
+    flow.run(engine)
+    flow.join()
+    if engine.failures():
+        engine.report_failures()
+        raise SystemExit(1)
+    print(f'Wrote {cfg.counts_path()}')
+
+
+if __name__ == '__main__':
+    main()

--- a/solutions/toy_router/toy_router_nodes.py
+++ b/solutions/toy_router/toy_router_nodes.py
@@ -1,0 +1,184 @@
+'''
+Glue nodes for the toy-router solution.
+
+These live in their own importable module (not in the graph module) because
+distributed workers reconstruct each node from its class path — recorded as
+``toy_router_nodes.<Class>`` — and importing the graph module in a worker would
+re-run graph-level code. Every constructor argument is stored as
+``self._<name>`` so the node round-trips through ``get_params()`` unchanged.
+
+``iter_events`` is the deterministic event stream shared by the producer and
+``prepare.py``: both sides walk the same PRNG, which is what lets the prep hook
+write the expected per-sensor totals *before* the flow runs.
+'''
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import time
+from collections.abc import Iterator
+from typing import Any, TextIO
+
+from videoflow.core.context import RuntimeContext
+from videoflow.core.node import ConsumerNode, ProcessorNode, ProducerNode
+
+
+def iter_events(seed: int, count: int, sensors: int) -> Iterator[dict]:
+    '''
+    Yields ``count`` events of the form ``{'seq', 'sensor', 'value'}``,
+    deterministically from ``seed`` — the single source of truth for both the
+    producer and the ground truth ``prepare.py`` bakes.
+    '''
+    rng = random.Random(seed)
+    for seq in range(count):
+        yield {
+            'seq': seq,
+            'sensor': f'sensor-{rng.randrange(sensors)}',
+            'value': round(rng.uniform(0.0, 100.0), 3),
+        }
+
+
+class EventProducer(ProducerNode):
+    '''
+    Emits the deterministic event stream, paced at ``rate_fps`` messages per
+    second (``<= 0`` = unpaced). Raises ``StopIteration`` when the stream is
+    exhausted — the finite-producer contract.
+    '''
+
+    def __init__(self, seed: int, count: int, sensors: int, rate_fps: float = 100.0,
+                 **kwargs: Any) -> None:
+        self._seed = seed
+        self._count = count
+        self._sensors = sensors
+        self._rate_fps = rate_fps
+        self._events: Iterator[dict] | None = None
+        super().__init__(**kwargs)
+
+    def open(self) -> None:
+        self._events = iter_events(self._seed, self._count, self._sensors)
+
+    def next(self) -> dict:
+        assert self._events is not None
+        event = next(self._events)  # StopIteration at the end ends the stream
+        if self._rate_fps > 0:
+            time.sleep(1.0 / self._rate_fps)
+        return event
+
+
+class AsyncEnricher(ProcessorNode):
+    '''
+    An ``async def process`` node: videoflow awaits coroutine results on a
+    task-owned event loop, so a node that needs async I/O (an HTTP lookup, an
+    async DB client) can await it directly without blocking broker fetches and
+    acks. The "lookup" here is simulated with ``asyncio.sleep``.
+
+    This node also stamps the routing key: ``ctx.set_partition_key`` attaches
+    the sensor id to the *next published message's* metadata (field
+    ``_partition_key``). Partition keys do not propagate through nodes on their
+    own — whichever node feeds a partitioned edge must stamp the key on its own
+    output, which is why the stamp lives here and not on the producer.
+    '''
+
+    def __init__(self, threshold: float = 50.0, lookup_ms: float = 1.0, **kwargs: Any) -> None:
+        self._threshold = threshold
+        self._lookup_ms = lookup_ms
+        super().__init__(**kwargs)
+
+    async def process(self, event: dict, ctx: RuntimeContext | None = None) -> dict:
+        await asyncio.sleep(self._lookup_ms / 1000.0)  # the pretend remote lookup
+        if ctx is not None:
+            ctx.set_partition_key(event['sensor'])
+        return {**event, 'bucket': 'high' if event['value'] >= self._threshold else 'low'}
+
+
+class KeyedCounter(ProcessorNode):
+    '''
+    A *stateful* processor that is nevertheless replicated — the combination
+    that is only correct under partitioned routing. The graph sets
+    ``nb_tasks=N, partition_by='_partition_key'``, so every message with the
+    same sensor id hashes to the same replica and each replica's per-sensor
+    counts are complete for the sensors it owns.
+
+    Flip the graph to ``partition_by='trace_id'`` and the pinning is by lineage
+    instead: every event has its own trace, one sensor's events spread across
+    replicas, and each replica counts only its share. The ledger consumer sums
+    the shares (so totals stay right either way), but records which replicas
+    touched each sensor — the visible difference between the two routings.
+    '''
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._counts: dict = {}
+        super().__init__(**kwargs)
+
+    def open(self, ctx: RuntimeContext | None = None) -> None:
+        if ctx is not None:
+            ctx.logger.info(f'counter replica {ctx.replica_id} open '
+                            f'(flow {ctx.flow_id}, run {ctx.run_id})')
+
+    def process(self, event: dict, ctx: RuntimeContext | None = None) -> dict:
+        count = self._counts.get(event['sensor'], 0) + 1
+        self._counts[event['sensor']] = count
+        return {
+            'seq': event['seq'],
+            'sensor': event['sensor'],
+            'bucket': event['bucket'],
+            'count': count,
+            'replica': ctx.replica_id if ctx is not None else 0,
+        }
+
+
+class LedgerWriter(ConsumerNode):
+    '''
+    The sink: appends every count update to ``ledger.jsonl`` and, from
+    ``close()``, writes ``counts.json`` — per-sensor totals (each replica's
+    last count, summed across replicas), which replicas touched each sensor,
+    whether the routing was sticky (exactly one replica per sensor), and
+    whether the totals match the ground truth ``prepare.py`` baked.
+
+    Construct with ``idempotent=True`` (the graph reads it from the config) and
+    the framework deduplicates ``consume()`` effects across broker redelivery,
+    when the flow has a Redis idempotency store.
+    '''
+
+    def __init__(self, ledger_path: str, counts_path: str,
+                 expected_path: str | None = None, **kwargs: Any) -> None:
+        self._ledger_path = ledger_path
+        self._counts_path = counts_path
+        self._expected_path = expected_path
+        self._shares: dict = {}    # (sensor, replica) -> that replica's last count
+        self._fh: TextIO | None = None
+        super().__init__(**kwargs)
+
+    def open(self) -> None:
+        self._fh = open(self._ledger_path, 'a')
+
+    def consume(self, update: dict) -> None:
+        assert self._fh is not None
+        self._fh.write(json.dumps(update) + '\n')
+        self._fh.flush()
+        self._shares[(update['sensor'], update['replica'])] = update['count']
+
+    def close(self) -> None:
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+        totals: dict = {}
+        replicas: dict = {}
+        for (sensor, replica), count in self._shares.items():
+            totals[sensor] = totals.get(sensor, 0) + count
+            replicas.setdefault(sensor, set()).add(replica)
+        report: dict = {
+            'totals': dict(sorted(totals.items())),
+            'replicas': {sensor: sorted(reps) for sensor, reps in sorted(replicas.items())},
+            'sticky': all(len(reps) == 1 for reps in replicas.values()) if replicas else None,
+            'matches_expected': None,
+        }
+        if self._expected_path:
+            try:
+                with open(self._expected_path) as f:
+                    report['matches_expected'] = report['totals'] == json.load(f)
+            except FileNotFoundError:
+                pass
+        with open(self._counts_path, 'w') as f:
+            json.dump(report, f, indent=2)

--- a/tests/integration/test_toy_solutions.py
+++ b/tests/integration/test_toy_solutions.py
@@ -1,0 +1,216 @@
+'''
+End-to-end tests for the three toy solutions under ``solutions/``.
+
+These are the widest integration tests in the suite. The other modules here
+assemble a graph in-process and run it; these drive the whole *user* path
+instead — ``videoflow run-local``, which generates nothing, runs the solution's
+``prepare.py`` hook, loads the graph module from disk, compiles it, provisions
+streams, spawns one worker subprocess per node replica, and waits for the flow
+to drain. What they assert is the solutions' own self-checking artifacts, so a
+pass means the distributed run computed the right answer, not merely that it
+exited zero.
+
+Two implementation details are load-bearing:
+
+**Each run gets a copy of the solution in a tmpdir.** ``build_flow()`` is called
+by ``load_flow`` with no arguments, so a solution always reads the
+``config.yaml`` sitting next to its own module — ``--config`` only reaches the
+prep hook. Copying the solution is therefore the only way to give a run its own
+config and work_dir without writing into the repo, and it keeps the three tests
+independent of each other and of any config.yaml a developer left behind.
+
+**Each solution runs in a subprocess, not in-process.** All three ship a
+``common.py`` and the graph modules import their glue nodes as top-level modules
+(``from toy_router_nodes import ...``) — the layout that lets a worker
+reconstruct a node from its ``<module>.<Class>`` path. Importing two solutions
+into one interpreter would collide on ``common``; a subprocess per solution is
+both the isolation and the honest reproduction of how these actually run.
+
+The configs below are deliberately smaller and faster than the shipped
+``config.example.yaml`` (short streams, high pacing): the point here is the
+framework path, and a CI run should not spend a minute on arithmetic. Skipped
+automatically when NATS is unreachable — see conftest.py.
+'''
+import json
+import os
+import pathlib
+import shutil
+import socket
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+import pytest
+import yaml
+
+NATS_URL = os.environ.get('VF_TEST_NATS_URL', 'nats://localhost:4222')
+REDIS_URL = os.environ.get('VF_TEST_REDIS_URL', 'redis://localhost:6379/0')
+
+SOLUTIONS_DIR = pathlib.Path(__file__).resolve().parents[2] / 'solutions'
+
+# A whole flow — provisioning, N worker subprocesses, drain and stream teardown.
+# Generous because it bounds a hang, not the expected runtime (~5-10s each).
+RUN_TIMEOUT_SECONDS = 300
+
+def _redis_available(url = REDIS_URL) -> bool:
+    '''
+    True when something is listening on the Redis host/port.
+
+    Only ``toy_router`` cares: its ledger consumer is built with
+    ``idempotent=True``, which needs a store to deduplicate against. Without one
+    the flow still runs correctly (redelivery just isn't deduplicated), so this
+    gates an *extra* argument rather than the test — CI runs a NATS server but no
+    Redis, and the solution must pass either way.
+    '''
+    parsed = urlparse(url)
+    try:
+        with socket.create_connection((parsed.hostname or 'localhost', parsed.port or 6379),
+                                      timeout = 1):
+            return True
+    except OSError:
+        return False
+
+def run_solution(tmp_path : pathlib.Path, name : str, config : dict,
+                 blob_redis : bool = False) -> pathlib.Path:
+    '''
+    Copies solution ``name`` into ``tmp_path``, writes ``config`` as its
+    config.yaml, runs it to completion with ``videoflow run-local``, and returns
+    the run's work_dir.
+
+    - Arguments:
+        - tmp_path: pytest's per-test temp directory; the copy and every \
+            artifact live under it.
+        - name: the directory name under ``solutions/``.
+        - config: the solution's config.yaml as a dict.
+        - blob_redis: point the run at Redis for the blob/idempotency store \
+            when one is reachable.
+
+    - Returns:
+        - the work_dir holding the solution's output artifacts.
+
+    - Raises:
+        - ``AssertionError`` with the captured output when the run fails.
+    '''
+    source = SOLUTIONS_DIR / name
+    assert source.is_dir(), f'solution not found: {source}'
+    work = tmp_path / name
+    work.mkdir()
+    # Only the Python modules: the graph, its glue nodes, the config loader and
+    # the prep hook. The Dockerfile and config templates play no part in a local
+    # run, and copying config.template.yaml would let run-local try to generate a
+    # config instead of using the one written below.
+    for module in source.glob('*.py'):
+        shutil.copy(module, work / module.name)
+    (work / 'config.yaml').write_text(yaml.safe_dump(config, sort_keys = False))
+
+    cmd = [sys.executable, '-m', 'videoflow.deploy.cli', 'run-local',
+           str(work / f'{name}.py'),
+           '--nats', NATS_URL,
+           # Never prompt and never start docker containers: the broker is the
+           # one this suite already probed for.
+           '--non-interactive', '--no-infra']
+    if blob_redis and _redis_available():
+        cmd += ['--blob-redis-url', REDIS_URL]
+
+    proc = subprocess.run(cmd, cwd = work, capture_output = True, text = True,
+                          timeout = RUN_TIMEOUT_SECONDS)
+    assert proc.returncode == 0, (
+        f'`run-local {name}` exited {proc.returncode}\n'
+        f'--- stdout ---\n{proc.stdout[-4000:]}\n'
+        f'--- stderr ---\n{proc.stderr[-4000:]}')
+    return work / 'out'
+
+def read_artifact(work_dir : pathlib.Path, filename : str) -> dict:
+    '''The named JSON artifact, failing with the directory listing when absent.'''
+    path = work_dir / filename
+    assert path.is_file(), (f'{filename} was not written; work_dir holds: '
+                            f'{sorted(p.name for p in work_dir.iterdir()) if work_dir.is_dir() else "nothing"}')
+    with open(path) as f:
+        return json.load(f)
+
+def test_toy_calculator(tmp_path):
+    '''
+    BATCH diamond: fan-out, a trace join re-aligning two branches, competing
+    replicas, stateful aggregation and a two-parent consumer.
+
+    ``matches_expected`` compares the flow's final statistics against the
+    closed-form values prepare.py baked before the run, so it is true only if
+    every integer crossed every edge exactly once and the join re-aligned all of
+    them — the loss-free guarantee BATCH exists to provide.
+    '''
+    work_dir = run_solution(tmp_path, 'toy_calculator', {
+        'work_dir': './out',
+        'start_value': 1,
+        'end_value': 40,
+        'producer_fps': 200,
+        'delay_fps': 150,
+        'flow_type': 'batch',
+        'square': {'workers': 2},
+        'join': {'timeout_s': None, 'missing': 'wait', 'max_pending': 100000},
+    })
+    report = read_artifact(work_dir, 'report.json')
+    assert report['matches_expected'] is True, report
+    assert report['pairs_seen'] == 40, report
+    assert report['final_stats']['count'] == 40, report
+
+def test_toy_router(tmp_path):
+    '''
+    Partitioned routing: an async ``process``, ``ctx.set_partition_key``, and a
+    stateful counter replicated across three partitions.
+
+    Both assertions matter and they are different claims. ``matches_expected``
+    says every event was counted exactly once; ``sticky`` says each sensor was
+    owned by exactly one replica — the property that makes replicating a
+    stateful node correct at all. A routing bug can easily preserve the totals
+    while losing stickiness.
+    '''
+    work_dir = run_solution(tmp_path, 'toy_router', {
+        'work_dir': './out',
+        'seed': 7,
+        'events': 120,
+        'sensors': 6,
+        'rate_fps': 400,
+        'idempotent_sink': True,
+        'enrich': {'threshold': 50.0, 'lookup_ms': 1.0},
+        'counter': {'partitions': 3, 'partition_by': '_partition_key'},
+    }, blob_redis = True)
+    counts = read_artifact(work_dir, 'counts.json')
+    assert counts['matches_expected'] is True, counts
+    assert counts['sticky'] is True, counts
+    assert sum(counts['totals'].values()) == 120, counts
+
+def test_toy_fusion(tmp_path):
+    '''
+    REALTIME fusion of independent producers by event time.
+
+    The cameras and the IMU share no lineage, so nothing here could be grouped
+    by trace id — the moments exist only because each producer stamps an event
+    timestamp and the join groups on it. ``duration_s`` bounds what is normally
+    an unbounded flow so the run drains and writes its summary.
+
+    The assertions stay above the timing noise a realtime path is allowed to
+    have: that moments were fused, that at least one saw every camera (the time
+    join really did group them rather than always emitting at quorum), and that
+    the collect parent delivered samples.
+    '''
+    work_dir = run_solution(tmp_path, 'toy_fusion', {
+        'work_dir': './out',
+        'cameras': 2,
+        'camera_fps': 10,
+        'phase_step_ms': 3.0,
+        'sensor_hz': 100,
+        'duration_s': 3,
+        'flow_type': 'realtime',
+        'fusion': {'tolerance_ms': 15, 'timeout_s': 0.25, 'quorum': 1,
+                   'sensor_window_ms': 40},
+    })
+    summary = read_artifact(work_dir, 'fusion_summary.json')
+    assert summary['moments'] > 0, summary
+    assert summary['complete_moments'] > 0, summary
+
+    latest = read_artifact(work_dir, 'latest.json')
+    assert latest['moment'] > 0, latest
+    assert latest['sensor_samples'] > 0, latest
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/todos/07_gap_analysis.md
+++ b/todos/07_gap_analysis.md
@@ -1,0 +1,407 @@
+# Videoflow functionality gap analysis — missing primitives for complex video processing
+
+## Context
+
+The user asked: review videoflow's functionality and identify missing-but-useful capabilities
+for video processing — specifically whether the processor types are sufficient, whether stateful
+processing is adequate, whether we need buffer-of-last-n-frames processors or marker-triggered
+buffers, and generally what would enable complex use cases like the soccer offside solution.
+
+This plan is the resulting gap analysis plus a prioritized, detailed design for the primitives
+worth building. **Scope decision (user, 2026-07-21): analysis/plan only for now — no
+implementation yet.** The roadmap below is the reference for whenever implementation is picked
+up. The evidence base is a full sweep of `videoflow/core`, `videoflow/messaging`,
+`spec/PROTOCOL.md`, all built-in and contrib components, and a trace of the offside solution's
+workarounds.
+
+## What exists today (baseline)
+
+- **Node types**: ProducerNode / ProcessorNode / ConsumerNode, plus `OneTaskProcessorNode`
+  (stateful ⇒ forced `nb_tasks=1`) — the only structural acknowledgement of state.
+  `TaskModuleNode` / `FunctionProcessorNode` / `ModuleNode` exist but are not distributable
+  (`get_params()` raises; `ModuleNode.__call__` is an unimplemented stub).
+- **Event-time joins** (`JoinPolicy(mode='time')`, `messaging/grouping.py`): tolerance-based
+  multi-parent alignment with quorum, per-parent `collect` windows, settle window, wall-clock
+  timeout. Real windowing — but only for *aligning parents*, not for aggregating a single
+  stream over time.
+- **Partitioned routing** (`partition_by`, PART-1..4): SHA-256 key-hash → replica ownership;
+  the closest thing to keyed state (a replica can hold per-key state in memory, but nothing
+  persists or migrates it).
+- **EOS drain** (EOS-1..6), at-least-once + DLQ, content-derived msg-id dedup (MSGID-1..3),
+  blob offload for >512KB payloads (`RedisBlobStore`, BLOB-1..7), sink idempotency (IDEM),
+  event-time propagation (LOOP-10), `ctx.set_event_timestamp` / `set_output_partition_key`.
+
+## The gaps (what the offside solution had to hand-roll)
+
+| # | Missing capability | Workaround observed |
+|---|---|---|
+| 1 | **Buffered/windowed processing** (last N items / last T seconds) | `offside_engine/engine.py` hand-rolls a `deque` of world states, wall-time trimming (`_trim_buffer`), nearest-timestamp lookup (`_state_nearest`), slice extraction |
+| 2 | **Marker/control streams** (trigger input that doesn't gate joins, broadcast to all replicas) | Touch/kick "markers" detected inline with manual `detection_lag_frames` future-context waits and `_committed_ts` dedup |
+| 3 | **Zero-or-many emission (flatMap)** | Event detectors return `None` on non-events; every downstream node open-codes `if item is None` guards (None is a legal payload, not a drop) |
+| 4 | **EOS flush / timer hooks** | No way to emit buffered state at end of stream; only `open()/close()` + per-item method |
+| 5 | **Managed keyed state / checkpointing** | State lives in instance attributes; replica restart loses it; time-join stages capped at `nb_tasks=1` |
+| 6 | **Named multi-output ports** | Splitter glue nodes (`FrameIndexSplitter`, `PersonBoxes`/`BallPick`, `KeypointsExtractor`/`BoundingBoxesExtractor`) + manual row-index re-alignment downstream |
+| 7 | **Frame store / media references** | `offside_visualizer` re-opens the source videos from disk (frames too big to ship through the broker); needs out-of-band paths + sync offsets |
+| 8 | **Watermarks** | Event-time completeness is wall-clock-timeout only |
+| 9 | **Ordering guarantees** | `seq` exists but is used only for dedup; no reorder buffer |
+| 10 | **Component stubs** | `ImageFolderReader`/`VideoFolderReader` raise `NotImplementedError`; `pose.py`/`counters.py` empty; writer is MJPG `.avi` only; no RTSP-out/mp4/clip-writer/OCR/zone-analytics |
+
+---
+
+## Recommended primitives (design)
+
+Build order: **P3 → P1 → P2 → P4/P5/P6**. P3 is smallest and both P1's EOS story and P2's
+triggered emission depend on it.
+
+### P3 (first): zero-or-many emission + `flush()` EOS hook
+
+**API surface** — two opt-in additions; every existing node stays byte-identical in behavior:
+
+```python
+# videoflow/core/node.py
+class _Skip:
+    '''Returned from process() to publish nothing for this input (unlike None,
+    which is a legal payload).'''
+    __slots__ = ()
+SKIP = _Skip()
+
+# on ProcessorNode (no-op default on ConsumerNode for symmetry):
+def flush(self) -> Any:
+    '''Called once after every parent has drained, *before* this node publishes
+    EOS. Emit buffered state via ctx.emit() (declare a ctx parameter); return
+    value treated exactly like a process() return (SKIP = publish nothing).'''
+    return SKIP
+```
+
+```python
+# videoflow/core/context.py — addition to RuntimeContext
+def emit(self, message : Any, metadata : Optional[dict] = None,
+        event_ts : Optional[float] = None, partition_key : Any = None) -> None:
+    '''Publish one output now, inside process()/flush(). Zero or more calls per
+    input; emissions publish in call order, before inputs are acked (LOOP-5
+    holds for every emission).'''
+```
+
+**Return-value rule in `ProcessorTask._run`** (exact back-compat): `SKIP` → publish nothing;
+anything else including `None` → publish as today. `ctx.emit()` calls are independent of the
+return value. Existing nodes never call emit and never return SKIP → identical behavior.
+
+**Identity minting (the protocol-sensitive part).** Today `publish_message` reuses
+`_last_trace_id/_last_seq`; two emissions for one input would collide on `Nats-Msg-Id` and
+JetStream would silently drop all but the first. Fix: messenger keeps a per-input-group
+emission counter `k`, reset in `receive_message`:
+- `k = 0`: carried-forward `trace_id`/`seq` unchanged — the single-output path keeps today's
+  exact wire identity including its message id.
+- `k >= 1`: `trace_id = f'{input_trace_id}.{k}'`, same `seq`. Deterministic across redelivery
+  (re-run re-emits in the same order → same ids → dedup holds, MSGID-2 preserved); distinct
+  trace ids also let a downstream trace-mode diamond join each emission with its own
+  descendants.
+- `flush()` emissions (no input group): `trace_id = f'{node_name}:flush:{k}'`, `seq = k`.
+  Documented as stable only across a graceful drain — a crash mid-flush loses buffered state
+  anyway.
+- `event_ts`: inherit the input group's (LOOP-10) unless the per-emission kwarg overrides.
+
+**Where it plugs in:**
+- `core/task.py` — `ProcessorTask._run`: check `output is SKIP`; in the stop-signal branch call
+  `self._call(self._processor.flush)` (publish its non-SKIP return / let emits go out)
+  **before** `publish_stop_signal()`. Same in `ConsumerTask._run` before `break`. Flush
+  failures are logged and must not prevent EOS propagation.
+- `core/engine.py` — add `emit_message(...)` to the `Messenger` base.
+- `messaging/nats_messenger.py` — implement `emit_message` (suffix logic, per-emission
+  `_partition_key` metadata), reset counter in `receive_message`, honor `has_children = False`
+  (emit becomes a no-op, mirroring LOOP-6).
+
+**RFC 0003** (`spec/rfcs/`): new MSGID-4 (fan-out sub-identity `{trace_id}.{k}`), LOOP-11
+(emit), LOOP-12 (flush-before-EOS), amend LOOP-3 (SKIP) and LOOP-10 (per-emission event_ts).
+No `.proto`/envelope change. Golden vectors: add message-id vectors for suffixed trace ids.
+**Size:** ~150 LOC code + ~250 LOC tests + spec/docs.
+
+### P1: `WindowedProcessorNode` — buffer of last N items / last T seconds
+
+**Decisive design constraint:** the window must be **node-local memory of already-acked
+history**, not messenger/assembler-held in-flight messages — `max_ack_pending` is deliberately
+tiny (6) and `ack_wait` bounds unresolved deliveries; a 450-frame window of un-acked handles
+would stall the pull loop or force early acks that break ack-after-process (DELIV-1). This
+means: no task.py/messenger/wire change at all; honest contract is "crash loses the buffer
+tail, it repopulates" — consistent with existing at-least-once semantics.
+
+```python
+# videoflow/core/window.py (new module — pure, broker-free, easily testable)
+class Window:
+    '''Read-only view over a node's buffered recent inputs, newest last.'''
+    @property
+    def items(self) -> list: ...
+    @property
+    def timestamps(self) -> list: ...        # event_ts, epoch seconds
+    def nearest(self, ts : float) -> tuple[Any, float]: ...
+    def between(self, start_ts : float, end_ts : float) -> 'Window': ...
+
+# videoflow/core/node.py
+class WindowedProcessorNode(ProcessorNode):
+    def __init__(self, window_count : Optional[int] = None,
+                window_seconds : Optional[float] = None,
+                window_key : Optional[str] = None, **kwargs : Any) -> None:
+        # at least one bound required; window_key ⇒ per-key windows, requires partition_by
+        ...
+    def process(self, inp : Any, ctx = None) -> Any:   # type: ignore[override]
+        # framework-implemented: append (event_ts, inp), dedup tail by (trace_id, seq)
+        # from ctx.input_info (redelivery-stable), trim by count/time, delegate:
+        ...
+    def process_window(self, window : Window, current : Any) -> Any:
+        raise NotImplementedError('process_window needs to be implemented by subclass')
+```
+
+Design points:
+- **Validation**: `nb_tasks > 1` without `partition_by` raises at build (competing replicas
+  would each see a random interleaving — no coherent window). `window_key` without
+  `partition_by` likewise rejected. Single **data** parent only in v1 (multi-camera cases
+  compose as time-join upstream → window downstream, exactly the fuser → engine chain);
+  enforced in `graph.py` next to the existing partition check.
+- Event time comes from `ctx.input_info[parent]['event_ts']` — already plumbed (LOOP-10).
+- EOS: subclasses that aggregate override `flush()` (P3) to emit final state.
+- `get_params()`: all three params are JSON scalars stored as `self._<name>`; buffer state is
+  not a ctor arg. Nothing to override.
+- Why not `ctx.window`: RuntimeContext is a per-call injection surface with no state; the
+  buffer must live across calls and its natural owner is the node instance (the
+  `OneTaskProcessorNode` precedent).
+
+**No RFC** (nothing observable on wire/routing) — but it is a node-contract change:
+update `.claude/docs/NODE_CONTRACT.md`, `docs/source/`, and contrib.
+**Files:** new `core/window.py` (~150 LOC), `core/node.py` (~90), `core/graph.py` (~20),
+~250 LOC tests (pure Window tests + task-level redelivery-dedup test).
+**Proving ground:** port `offside_engine`'s deque/`_state_nearest`/`_trim_buffer` onto
+`Window.between`/`nearest`.
+
+### P2: control/marker inputs — `control=['parent-name']`
+
+A parent designated as **control** is not a data input: it never gates join completeness or
+quorum, is **broadcast to every replica** (bypasses `_owns()`), and is delivered via a
+dedicated callback. Declared by parent *name* (a node's name is already its cross-process
+identity — live node references would break the JSON `get_params()` round trip):
+
+```python
+# ProcessorNode/ConsumerNode.__init__ gain: control : Optional[list] = None
+clip_maker = ClipMaker(window_seconds = 8.0, control = ['kick-detector'],
+                    name = 'clip-maker')(fuser, kick_detector)
+
+# node callback (optional ctx; async supported via the existing _call bridge):
+def on_control(self, parent_name : str, message : Any, ctx : RuntimeContext) -> None:
+    '''Called per message from a control parent, on the same single task thread
+    as process() — never concurrently with it.'''
+```
+
+**Semantics:**
+1. Control parents are excluded from `parent_names` positional order; `process(*inputs)` sees
+   only data parents; the assembler never sees control entries.
+2. **Broadcast delivery**: new durable family in `topology.py` —
+   `{child}--ctl--{parent}--p{replica_id}` (new NAME-10), provisioned for every replica in
+   `provision_flow` (mirroring the partitioned branch). Dedicated pull loop + queue per
+   control parent in the messenger; `_owns()` bypassed.
+3. **Prompt delivery**: `receive_message()` checks control queues *before* the assembler, so a
+   marker on a quiet data stream returns immediately (entry carries `'is_control': True` +
+   parent name). `ProcessorTask._run`/`ConsumerTask._run` branch: dispatch
+   `self._call(node.on_control, parent, message)`, then `ack_inputs()`/`fail_inputs()` with
+   the same at-least-once discipline. The messenger sets `_last_trace_id/_last_seq/_last_event_ts`
+   from the control entry, so `ctx.emit()` inside `on_control` mints output identity derived
+   from the marker — a redelivered marker re-emits the same clip id and JetStream dedups it
+   (this is why P2 depends on P3).
+4. **EOS**: loop termination driven by **data** parents only (new EOS-7); on data-drain the
+   messenger drains queued control messages, terminates control consumers, calls `flush()`,
+   publishes EOS. A never-ending trigger source must not wedge BATCH shutdown; a control
+   parent finishing early must not stop the node.
+5. **Delivery class**: control rides JetStream at-least-once (a missed kick is a missed clip),
+   *not* the fire-and-forget plain-NATS `_control.stop` style.
+6. **Validation** (`graph.py`): every `control` name is an actual parent; ≥1 data parent
+   remains; the class overrides `on_control` (reject the silent-drop foot-gun); windowed/
+   partition rules count data parents only.
+
+**End-to-end clip use case:** `ClipMaker(WindowedProcessorNode)` with `window_seconds = 8`;
+`on_control` appends trigger `t` (dedup by marker trace_id); `process_window` checks per data
+input whether `newest_event_ts >= t + 2.0` and then
+`ctx.emit(window.between(t - 5.0, t + 2.0).items)` — past frames from P1's buffer, future
+frames by letting event time pass the trigger, 0..N emission via P3.
+
+**Files:** `core/node.py` (param + stub), `core/compiler.py` (`NodeSpec.control` — **appended
+last**; field order is the constructor signature; `to_dict`/`from_dict`), `runtime/worker.py` +
+`engines/local.py` + `deploy/manifests.py` (`VF_CONTROL_PARENTS`), `core/graph.py`,
+`messaging/topology.py`, `messaging/nats_messenger.py` (control pull loops, queue priority,
+`_owns` bypass, EOS-7 drain), `core/task.py`, `core/engine.py` (document extended
+`receive_message` shape).
+
+**RFC 0004** — the heaviest: NAME-10; a CONTROL requirement family (delivery/ordering/ack);
+EOS-7; PART-5 note (control bypasses ownership); ENV row for `VF_CONTROL_PARENTS`; amend ENV-3
+(positional order = data parents). No wire/envelope change — control messages are ordinary
+envelopes on the parent's ordinary stream; only routing (durables) and loop behavior change.
+**Size:** ~450–700 LOC + ~300 LOC tests (broadcast to `nb_tasks=3`, marker-redelivery dedup of
+the emitted clip, EOS-7 with a non-terminating control parent) — largest of the three temporal
+primitives.
+
+### P4: named multi-output ports
+
+**Declaration** — ports are intrinsic to a class, so a class attribute (read by the compiler,
+not `get_params()`); contract v1: a multi-port node returns a dict containing **every**
+declared port each round (`None` legal and published — preserves exact trace-alignment so
+downstream trace joins never stall; selective emission deliberately deferred):
+
+```python
+class SoccerDetector(ProcessorNode):
+    output_ports : ClassVar[tuple[str, ...]] = ('players', 'ball')
+    def process(self, frame : np.ndarray) -> dict:
+        return {'players': person_dets, 'ball': ball_pick}
+
+# wiring — Node.__getitem__ returns a frozen OutputPort(node, port) accepted by __call__:
+dets = SoccerDetector(...)(frame)
+tracks = BoxmotTracker(...)(frame, dets['players'])
+packer = FeaturePacker(...)(tracks, pose, team, dets['ball'])
+```
+
+Producers get ports too — `VideostreamReader` can declare `('frame', 'index')`, killing
+`FrameIndexSplitter`. `__call__` unwraps ports into `self._parents` (still Node objects, so
+`has_cycle`/`topological_sort` untouched) + a parallel `self._parent_ports`.
+
+**Edge identity (load-bearing):** qualified refs `'{parent}:{port}'` threaded through
+unchanged plumbing — `build_tasks_data()` emits them, `NodeSpec.parents` stores them,
+`VF_PARENT_NAMES` carries them, one `split_edge(ref) -> (node, port | None)` helper in
+`topology.py` parses them. Two ports of the same parent to one child work for free (distinct
+dict keys in `receive_message()`, distinct durables). `NodeSpec` gains appended
+`output_ports : Optional[List[str]]`.
+
+**Subject/stream mapping:**
+- Port subject `vf.{flow}.{run}.{node}.{port}` (default output keeps the bare subject); port
+  names sanitized, must not start with `_` (the `._eos` namespace position).
+- Still one stream per node, binding data + port + eos subjects.
+- **REALTIME trap:** today `max_msgs = max(1, realtime_buffer)` + `DiscardPolicy.OLD` — port B
+  would evict port A. Multi-port streams must use `max_msgs_per_subject` instead; scope to
+  multi-port streams so existing configs stay byte-identical.
+- Durables `{child}--from--{parent}--{port}` (NAME-5/6 amendment); partition suffix `--p{n}`
+  composes on top. Filter subject = port subject, so a `'ball'` subscriber never receives
+  `'players'` payloads — the real bandwidth/decode win over splitters.
+- **EOS stays per node, not per port** (all ports end when the task loop ends; a
+  ball-only child still observes node EOS) — the single biggest scope-saver.
+- `publish_message` splits the returned dict, one envelope per port with the same
+  `trace_id`/`seq`/`event_ts` (downstream re-zip by trace join is automatic). Envelope format
+  unchanged → no golden-vector changes (verify, don't assume).
+- Blob refcounting becomes per-port: `blob_readers_by_port : Optional[Dict[str, int]]`
+  (appended field) + `VF_BLOB_READERS_JSON`; over-counting is safe (TTL backstop),
+  under-counting never.
+
+**Also touched:** `component.yaml` needs `io.outputs: [{name, type}]`
+(`components/descriptor.py`, `core/remote.py`); KEDA trigger durable enumeration in
+`deploy/manifests.py` must include port durables. Does **not** fix the time-join `nb_tasks=1`
+ceiling — out of scope.
+
+**RFC 0005**: amend NAME-2/5/6, STREAM-1/2, BLOB-5, ENV (`VF_PARENT_NAMES` qualified refs,
+`VF_OUTPUT_PORTS`, `VF_BLOB_READERS_JSON`). **Acceptance test:** portless flows produce
+byte-identical `NodeSpec.to_dict()`, subjects, durables, stream configs.
+**Size:** ~700–900 LOC — the largest single item. In offside it deletes 3 glue classes and
+~9–12 worker pods (3 glue × N cameras) plus both human_tracking extractors.
+
+### P5: frame store / media references (no protocol change)
+
+**Verdict:** thin policy layer over the existing `BlobStore` machinery; do **not** reuse the
+wire-level `BlobRef` — that is auto-resolved at decode (BLOB-3) and refcount-released on ack
+(BLOB-6), exactly wrong here: resolution must be lazy/conditional (only rare event frames are
+fetched) and readership is unknown at compile time. A `FrameRef` is a plain JSON dict payload;
+storage via `BlobStore.put()` (TTL, no refcount — BLOB-7 semantics). Pure library addition.
+
+```python
+# new: videoflow/media/frames.py
+class FrameStore:
+    def __init__(self, blob_url : str, retention_seconds : int = 120,
+                encoding : str = 'jpeg', jpeg_quality : int = 90) -> None: ...
+    def open(self) -> None: ...     # make_blob_store(url) here — no I/O in __init__
+    def put(self, cam : str, frame_idx : int, event_ts : float,
+            frame : np.ndarray) -> dict:
+        '''Returns {'cam','frame_idx','event_ts','ref','encoding','shape'}'''
+    def resolve(self, frame_ref : dict) -> np.ndarray: ...
+
+class RedisFrameCache(FrameStore):
+    '''Adds a per-camera Redis zset time index (score = event_ts), trimmed on put.'''
+    def frames_between(self, cam : str, t0 : float, t1 : float) -> list[dict]: ...
+    def nearest(self, cam : str, event_ts : float, tolerance_s : float = 0.05) -> dict | None: ...
+```
+
+- Producer opt-in: `VideostreamReader(..., frame_cache_url : str | None = None,
+  frame_retention_seconds : int = 120)` — `next()` puts each frame and exposes a `frame_ref`
+  (extra output port once P4 lands; opt-in tuple element before that).
+- Retention is the TTL: size guidance `fps × cams × retention × jpeg_size` (30fps × 3 × 120s ×
+  ~150KB ≈ 1.6GB) — document Redis `maxmemory` + optional downscale param. A missing frame at
+  resolve time degrades (skip overlay), never crashes.
+- **Honest scoping:** for the current BATCH offside solution, re-reading files from disk is
+  actually principled (the file outlives any cache; Interest-retention backlog can exceed any
+  affordable window). The win is REALTIME/live flows and the event-clip writer. Keep the disk
+  path as the BATCH fallback.
+
+**No RFC.** ~250 LOC `media/frames.py` + ~40 in `producers/video.py` + tests/docs.
+
+### P6: component fills (prioritized by demand from real solutions)
+
+| # | Component | Placement | Size | Notes |
+|---|---|---|---|---|
+| 1 | **Mp4 `VideoWriter`** — extension-driven fourcc (`.mp4`→`avc1`, fallback `mp4v`; `.avi`→`MJPG`), `fourcc : str = 'auto'`; writer created lazily on first frame (needs dims); keep `VideofileWriter` as frozen alias | core (`consumers/video.py`) | ~120 LOC | All three solutions emit browser-unplayable MJPG `.avi` today. Contrib `pyav_writer/` for guaranteed H.264 (check PyAV codec licensing) |
+| 2 | **`ImageFolderReader`/`VideoFolderReader`** — glob + sorted order, per-file iteration, `event_ts` stamping, hand-written `get_params()` | core (`producers/video.py`) | ~150 LOC | Currently `NotImplementedError` stubs |
+| 3 | **`counters.py`**: `LineCrossingCounter(lines : dict[str, list[list[float]]])` + `ZoneIntrusionDetector(zones, min_frames : int = 1)`, both `OneTaskProcessorNode`, input `(N,5)` tracks, output `{'counts', 'events'}`, pure numpy | core | ~250 LOC | Natural next stage after tracking; v2 can `partition_by='cam'` |
+| 4 | **`EventClipWriter`** consumer — consumes `{'cam','event_ts'}` events, pulls `[t−pre, t+post]` via `RedisFrameCache.frames_between`, writes mp4. Post-roll via a deferred-work queue drained on later `consume()` calls (blocking `consume()` stalls acks) | core | ~180 LOC | **Gated on P5** — pre-roll cannot live in-node (REALTIME retention; crash loses in-memory buffers) |
+| 5 | **RTSP/RTMP restreamer** — `RtmpRestreamer(url, fps = 30.0, bitrate = '3M', encoder = 'libx264')`; ffmpeg subprocess pipe opened in `open()`, restarted on death | contrib + `component.yaml` + Dockerfile | ~200 LOC | Live output for offside/human_tracking |
+| 6 | **`pose.py` abstract base** — `PoseEstimator(ProcessorNode)` + COCO keypoint constants, mirroring `detectors.py`; `pose_topdown` subclasses it | core | ~60 LOC | Consistency with the domain-base rule |
+| 7 | **OCR** | contrib (heavy ML deps) | ~150 LOC | Plates/jerseys demand exists; nothing current needs it |
+
+Rejected for now: WebRTC output consumer — per-viewer signaling/session state doesn't fit the
+one-node-per-pod model; restream to MediaMTX and let it terminate WebRTC.
+
+---
+
+## Design rejects (recorded so we don't relitigate)
+
+- **Messenger/assembler-held windows** (a JoinPolicy-style `window=` knob): window contents
+  would be un-acked in-flight deliveries; `max_ack_pending`(=6)/`ack_wait` make that a stall
+  or an early-ack that breaks DELIV-1.
+- **Redis-backed keyed state / checkpointing of buffers**: a future, much larger RFC
+  (watermark/timer/checkpoint territory). Buffers are best-effort task-local memory for now.
+- **Generator/`yield`-based `process()`** for flatMap: breaks the `(class path, get_params())`
+  round trip and the async `_call` bridge; `ctx.emit` achieves 0..N without changing the
+  callable form.
+- **Making `None` a drop sentinel**: silently changes wire behavior of every existing flow.
+- **Control parents by node reference**: live refs break JSON serialization — names only.
+- **Broadcasting control on plain NATS** (like `_control.stop`): loses at-least-once for
+  data-critical markers.
+- **`window_key` without `partition_by`**: per-key windows on competing replicas shard each
+  key's history randomly — enforced by validation.
+- **Watermarks / tumbling / session windows / event-time timers**: need a progress notion
+  across parallel sources + a timer service, none of which the envelope carries. Deferred;
+  `window_seconds` is documented as a sliding tail, not an aligned window.
+
+## Roadmap (suggested sequencing)
+
+| Phase | Items | RFC | Rough size |
+|---|---|---|---|
+| 1 — quick wins | Mp4 writer, folder readers, `pose.py` base | none | ~330 LOC |
+| 2 — temporal core | P3 emit/SKIP/flush → P1 `WindowedProcessorNode` | 0003 (P3 only) | ~400 LOC + tests |
+| 3 — triggers | P2 control inputs → P5 frame store → `EventClipWriter` | 0004 | ~900 LOC + tests |
+| 4 — structure | P4 named output ports | 0005 | ~700–900 LOC |
+| 5 — analytics | counters, restreamer, OCR | none | parallel with 4 |
+
+(RFC numbers assigned here to resolve a collision between the two designs; final numbers
+follow whatever exists under `spec/rfcs/` at implementation time.)
+
+Deferred to a future, larger effort (explicitly not in this plan): watermarks, aligned
+tumbling/session windows, durable keyed state + checkpointing, scaling time-mode joins past
+`nb_tasks=1`, cycles/iterative dataflow.
+
+## Verification
+
+- **Unit:** pure `Window` tests (nearest/between/trim/dedup); ctor validation tests
+  (window bounds, `window_key`⇒`partition_by`, control-name validation);
+  `NodeSpec.to_dict` byte-identity before/after (the repo's stated acceptance test);
+  `topology.py` naming tests for `--ctl--` and port durables.
+- **Integration** (`tests/integration/`, live NATS): fan-out dedup under forced redelivery
+  (P3); flush-before-EOS ordering (P3); control broadcast to `nb_tasks=3` replicas +
+  marker-redelivery dedup of the emitted clip + EOS-7 with a non-terminating control parent
+  (P2); multi-port stream retention under REALTIME (P4).
+- **Golden vectors:** MSGID-4 suffixed ids (`spec/vectors/`, regenerate via `generate.py`);
+  verify P4 leaves vectors unchanged.
+- **Contrib proving ground:** migrate `offside_engine`'s buffer to `WindowedProcessorNode`;
+  add a `toy_*`-style dependency-free exerciser solution for control inputs (the established
+  pattern for framework features); later, port the offside branch to output ports.
+- **Docs in same commits:** `spec/PROTOCOL.md` + RFCs, `.claude/docs/NODE_CONTRACT.md` +
+  `ARCHITECTURE.md` extension-seam table, `docs/source/`, `README.md`, contrib `CLAUDE.md`.

--- a/todos/08_checkpointing of buffers.md
+++ b/todos/08_checkpointing of buffers.md
@@ -1,0 +1,203 @@
+# Exploration: Redis-backed keyed state / checkpointing of buffers
+
+> **Deliverable decision (user, 2026-07-21): answer only — no files written to the repo.**
+> This document is the exploration record; nothing below is to be implemented now.
+
+## Context
+
+`todos/07_gap_analysis.md` gap #5 records that videoflow has no managed state: state lives in
+instance attributes (`OneTaskProcessorNode` forces `nb_tasks=1`; partitioned replicas hold
+per-key state in memory), a replica restart loses it, and the item was deferred as "a future,
+much larger RFC (watermarks/timers/checkpoint territory)". This exploration designs that RFC's
+core: durable per-key state for processor/consumer nodes so a worker restart within a run
+resumes instead of cold-starting. It was produced by a three-way codebase exploration (state
+& buffers, Redis infrastructure, protocol/lifecycle) plus two independent design passes
+(mechanism design + adversarial risk review) reconciled below.
+
+## Finding that narrows the scope
+
+**Join/window buffers held by the messenger need no checkpointing.** `messaging/grouping.py`
+assemblers hold entries with **un-acked** broker handles; a crash leaves them pending on
+JetStream and redelivery repopulates the buffers — the broker already *is* the checkpoint.
+The genuinely unprotected asset is **per-key node state accumulated over already-acked
+history** (trackers, aggregators, counters). That is the sole target. (P1's future
+`WindowedProcessorNode` keeps its honest "crash loses the tail" node-local buffer; a durable
+window becomes a later opt-in built on this feature's ListState successor.)
+
+## Design summary
+
+### API: `ctx.state` (ValueState only in v1)
+
+```python
+# inside process()/consume() of a node declared durable_state=True
+n = ctx.state.get('count', default=0)     # cold-loads scope from Redis on first touch
+ctx.state.put('count', n + 1)             # eager wire-encode; staged, not yet persisted
+ctx.state.delete('old_slot')
+```
+
+- Scope is implicit: partitioned node → the current message's partition key; `nb_tasks=1`
+  node or consumer → a singleton `_` scope. No cross-key reads (a replica only owns its keys).
+- Values = anything the v4 payload codec accepts (ndarray, protobuf, JSON-like). Encoded via
+  new thin public wrappers `encode_payload`/`decode_payload` over the existing private
+  `_encode_payload_v4`/`_decode_payload_v4` in `videoflow/wire/serialization.py` — **no blob
+  offload** (BlobRef's compile-time reader counts and ack-driven release don't fit state);
+  warn >1MB, hard error at a cap. `put()` is the persistence point (`get` returns by
+  reference; mutating without `put` persists nothing).
+- `ctx.state` without `durable_state=True` or outside a group → `RuntimeError` naming the fix.
+
+### Commit protocol (the heart of the design)
+
+Per input group, extending the existing loop in `core/task.py` (`ProcessorTask._run`
+lines 197–218, `ConsumerTask._run` 246–267), which mirrors the existing consumer-idempotency
+pattern (seen → consume → mark → ack):
+
+```
+receive → [if redelivered (num_delivered>1) and marker exists: ack, skip]
+        → session.begin(scope, gid)      # gid = messenger.last_input_key()  (already exists)
+        → process/consume                # puts go to a per-group STAGING buffer
+        → publish (unchanged, LOOP-5)
+        → session.commit()               # atomic Redis MULTI: dirty slots + marker; no-op if clean
+        → ack_inputs()
+on exception: session.discard() → fail_inputs()   # staging dropped — retry can't double-apply
+```
+
+Crash matrix (BATCH): crash before commit → redeliver → reprocess against pre-group state →
+republish (deduped by content-derived `Nats-Msg-Id`, MSGID-1/2) → commit once. Crash after
+commit, before ack (incl. silently-swallowed ack failures) → redeliver → **marker hit → skip
+process and publish** (publish already broker-acked before commit) → ack. Delta applied
+exactly once relative to acked history.
+
+Key reconciled decisions and why:
+
+1. **Per-group marker keys, not a per-scope marker field.** Swallowed ack failures redeliver
+   ~`ack_wait` (60s) later; a busy scope commits ~1800 more groups meanwhile, overwriting any
+   single marker → double-apply. Marker = `vf-state-app:{<state hash key>}:<gid>` (braces =
+   Redis Cluster hash tag, so marker + state hash share a slot and one MULTI covers both).
+   Written only on dirty commits; TTL `max(600, 10 × ack_wait)`; consulted only when
+   `num_delivered > 1` → **zero happy-path reads**. `gid` reuses `last_input_key()`
+   (`nats_messenger.py:518` — `derive_message_id` over trace_id+seq), the same identity the
+   sink-idempotency store already trusts.
+2. **Staging buffer, not naive write-through cache.** `fail_inputs` retry is a *routine* path
+   (task.py:216–218); a cache mutated before a publish failure would double-apply without any
+   crash. Writes stage per group; fold into the read cache only on successful commit.
+3. **Per-group commit, not interval snapshots.** Exactly-once snapshots need ack deferral;
+   `max_ack_pending = 6` caps that at 6 messages — epochs are structurally unavailable
+   (same reason the gap analysis rejected messenger-held windows). One pipelined RTT per
+   *dirty* group on colocated Redis is noise against ML proctime.
+4. **Marker consultation is BATCH-only.** REALTIME has `max_deliver=1` (no redelivery — the
+   marker's trigger can't fire), and a restarted REALTIME producer re-mints trace ids from 1
+   (MSGID-3), so a long-lived marker would silently skip *new* frames. REALTIME still
+   commits (restart recovery); a crash between publish and commit loses that one delta —
+   consistent with freshest-wins.
+5. **Fencing epoch in v1** (risk reviewer's finding, adopted): Indexed-Job replacement pods
+   overlap terminating ones (~30s dual-writer per index on BATCH node loss), and StatefulSet
+   at-most-one isn't absolute. Per-(node, replica) epoch key: `INCR` at task open; every
+   commit is `WATCH epoch / GET / compare / MULTI…EXEC` (no Lua, honoring the RFC-0002
+   no-EVAL precedent; +1 cheap RTT on dirty commits only). Fenced writer logs and exits; its
+   un-acked inputs redeliver to the survivor, whose marker check absorbs already-published
+   groups. Combined with workload hardening (below) so fencing events stay rare.
+6. **Commit failure ≠ fail_inputs on BATCH.** Naks cap at 30s → a 2-minute Redis blip would
+   DLQ groups flow-wide. Instead: blocking retry with backoff until the termination event
+   (the DELIV-5 publish-backpressure precedent; the keepalive loop already extends held acks
+   on its own thread, so a blocked task thread never triggers spurious redelivery). REALTIME:
+   log-and-ack (state lags one message; freshest-wins-consistent).
+
+### Redis data model
+
+```
+vf-state:<flow_id>:<run_id>:<node>:<scope>          # ONE hash per scope; field s:<slot> = framed payload
+vf-state-app:{vf-state:<flow>:<run>:<node>:<scope>}:<gid> = 1, EX ~600   # applied marker
+vf-state-epoch:<flow>:<run>:<node>:<replica>        # fencing epoch (INCR at open, WATCHed at commit)
+```
+
+Framing per slot: `0x01 | u16 len | payload_type utf-8 | payload bytes` (language-neutral for
+future SDKs). Scope TTL `VF_STATE_TTL_SECONDS` (default 86400), refreshed on commit and cold
+read — only idle scopes expire. Missing/expired/evicted/undecodable state reads as defaults
+with a loud log — **never a crash** (run-scoped; new `run_id` = deliberate cold start).
+Cleanup: TTL backstop (BLOB-7 philosophy) + best-effort `SCAN`+`UNLINK` of the run prefix at
+teardown. **No scheme registry in v1** — direct `RedisKeyedStateStore(url)` behind a small ABC
+(the `IdempotencyStore` precedent; `Redis.from_url` already handles redis/rediss/unix);
+the blob-store-style registry is the obvious seam when a second backend appears.
+
+### Who may use it — graph validation (`core/graph.py`, beside the existing join/partition rule)
+
+| Config | Verdict |
+|---|---|
+| Processor/consumer `nb_tasks=1` (incl. `OneTaskProcessorNode`) | allowed — singleton scope |
+| Processor `partition_by=<metadata field>`, `nb_tasks>1` | allowed — per-key scope; static `hash % nb_tasks` ownership (PART-3) |
+| `partition_by='trace_id'` + `nb_tasks>1` | **rejected** — trace_id unique per message: one dead hash per message, no continuity |
+| Non-partitioned `nb_tasks>1` | **rejected** — competing consumers, no stable scope |
+| Multi-parent **time-mode** join | **rejected in v1** — group identity (`tw-<µs>`) shifts when membership re-forms after a crash; marker undefined. Single-parent nodes *downstream* of a time join are fine (their gid is the fused message's own stable id) |
+| Producers | **not offered** — a durable resume cursor without a durable trace counter collides restarted `Nats-Msg-Id`s into silent dedup-loss (MSGID-3); needs its own RFC |
+
+Deploy/run-time: `durable_state` anywhere + no Redis URL ⇒ fail before start (CLI) and at
+worker startup — never a silent in-memory fallback.
+
+### Deployment consequences
+
+- REALTIME `durable_state` nodes become **StatefulSets even at `nb_tasks=1`** (Deployments
+  surge/overlap on rolling updates and eviction — routine dual-writers). `workload()` gate in
+  `deploy/manifests.py` becomes `_is_partitioned(spec) or (spec.durable_state and not batch)`;
+  headless service + `POD_NAME` injection follow.
+- **KEDA never autoscales a `durable_state` node** (`scaled_object` exclusion alongside the
+  existing partitioned exclusion).
+- Env plumbing: `VF_DURABLE_STATE` per node; `VF_STATE_REDIS_URL` (fallback
+  `VF_BLOB_REDIS_URL` — reaches every pod via the existing nats ConfigMap already) and
+  `VF_STATE_TTL_SECONDS` in the ConfigMap; CLI flags `--state-redis-url`/`--state-ttl-seconds`.
+- Honesty: dev Redis is `--save "" --appendonly no --maxmemory 4gb --maxmemory-policy
+  volatile-lru` — state survives **pod** restarts (the target case), not Redis restarts, and
+  TTL'd keys are LRU-evictable under blob memory pressure (logical DBs don't isolate
+  maxmemory). Production posture: dedicated persistent (AOF) `noeviction` Redis via
+  `VF_STATE_REDIS_URL` — deliberately different tuning from the blob cache.
+
+## Modifications inventory
+
+| File | Change | ~LOC |
+|---|---|---|
+| `videoflow/runtime/state.py` **(new)** | `KeyedStateStore` ABC, `RedisKeyedStateStore` (lazy `import redis`), `StateSession` (staging, cache, begin/commit/discard, marker check, epoch fence), `scope_for`, key builders | ~330 |
+| `videoflow/wire/serialization.py` | public `encode_payload`/`decode_payload` wrappers | ~15 |
+| `videoflow/core/context.py` | `state` property (TYPE_CHECKING import per task.py precedent); actionable `RuntimeError` when absent | ~15 |
+| `videoflow/core/task.py` | optional `state_session=` ctor arg (idempotency-store precedent); marker-skip + begin/commit/discard around the two run loops; consumer idem ordering (marker check → consume → state commit → idem mark → ack) | ~50 |
+| `videoflow/core/node.py` | `durable_state : bool = False` param + property on `ProcessorNode`/`ConsumerNode`, stored as `self._durable_state` (get_params auto-capture) | ~15 |
+| `videoflow/core/graph.py` | the rejection rules above, `ValueError`s naming the fix | ~25 |
+| `videoflow/core/compiler.py` | `NodeSpec.durable_state : bool = False` **appended last** (field order is the ctor signature); `to_dict`/`from_dict` | ~10 |
+| `videoflow/core/engine.py` + `messaging/nats_messenger.py` + `runtime/health.py` | `Messenger.last_input_redelivered()` (max `num_delivered` over the group's handles, recorded in `receive_message`); `InstrumentedMessenger` delegation | ~25 |
+| `videoflow/runtime/worker.py` | env parse, fail-fast, store/session construction, epoch mint, pass to task + ctx | ~35 |
+| `videoflow/engines/local.py` | `VF_DURABLE_STATE`/`VF_STATE_REDIS_URL` pass-through | ~10 |
+| `videoflow/deploy/manifests.py` | env pairs, ConfigMap entries, StatefulSet gate, KEDA exclusion | ~40 |
+| `videoflow/deploy/cli.py` | flags + deploy-time "durable_state needs Redis" check | ~30 |
+| `spec/PROTOCOL.md` | new §15 Keyed state: **STATE-1..8** (enablement, scope, layout, commit order incl. commit-only-after-PubAck as a MUST, marker, guarantee levels, TTL/missing-reads-as-default, single-writer + fencing) | ~90 lines |
+| `spec/rfcs/000N-keyed-state.md` | next free number; template sections; Alternatives records: interval snapshots (max_ack_pending), single/ring markers, fingerprint gids, NATS KV backend, Lua commits; Open questions: always-consult markers vs redelivered-only, fencing ping-pong under kubelet partition, retry-forever vs eventual-DLQ on Redis outage | ~180 lines |
+| Docs same-commit | `.claude/docs/NODE_CONTRACT.md` + `ARCHITECTURE.md` seam table, `docs/source/`, `README.md`, contrib `CLAUDE.md` | ~80 lines |
+
+**Total ≈ 600 LOC code + ~500 LOC tests** (`tests/test_keyed_state.py` with a `_FakeRedis`
+dict fake per the blob-refcount test pattern; graph rejection cases; NodeSpec round-trip +
+**byte-identity of specs/manifests for flows without the flag** as the acceptance test;
+integration: kill-and-restart a stateful replica mid-BATCH and assert exact counts, forced
+redelivery hits the marker, 3-replica per-key isolation, REALTIME loss-tolerance smoke).
+
+## Sequencing & out of scope
+
+Lands independently of the gap-analysis roadmap but best **after Phase 2 (P3 → P1)**; the one
+forward-compatibility ask on P3 is to route ack/fail through a single task-level choke point
+(commit/abort hook beside `ack_inputs`/`fail_inputs`) that both this feature and P2's
+`on_control` will need, and to keep every `ctx.emit` PubAck synchronous so commit-after-publish
+stays sound.
+
+Deferred, one line each: **timers/watermarks** (need a progress notion + tick service the
+envelope lacks); **rescaling partitioned nodes** (static `hash % nb_tasks`; rescale = key
+migration protocol); **time-join scaling past nb_tasks=1** (broker-topology problem, untouched);
+**ListState/durable windows** (single prospective caller; P1 stays memory-first);
+**cross-run resume** (fresh trace ids vs stale markers = institutionalized skip-loss);
+**producer state** (MSGID-3 amendment required); **IDEM unification** (markers subsume it
+conceptually; freeze and note convergence in the RFC).
+
+## Verification (when implemented)
+
+- Unit: commit atomicity ordering, marker-on-dirty-only, staging discard on fail, `scope_for`
+  PART-2 stringification, framing round-trip, TTL refresh, fence rejection.
+- Byte-identity: rendered manifests + `NodeSpec.to_dict` unchanged for existing flows.
+- Integration (live NATS + Redis): kill a stateful replica mid-BATCH → exact counter on
+  completion; forced redelivery → marker skip; REALTIME crash → bounded single-delta loss.
+- Contrib proving ground: offside `offside_engine` committed-timestamp dedup state moves to
+  `ctx.state`; restart the engine pod mid-game and verify no duplicate/lost events.


### PR DESCRIPTION
Moves the three dependency-free solutions — `toy_calculator`, `toy_fusion`, `toy_router` — from `videoflow-contrib/solutions/` into this repo, and puts them to work as the framework's end-to-end test suite.

**Paired with videoflow/videoflow-contrib#36, which removes them there.** Merge this one first so the toys are never absent from both repos.

## Why they belong here

They import no `videoflow_contrib` packages — only core nodes, no models, no footage. Contrib's own docs already flagged them as the odd ones out ("the only solutions that run with `videoflow run-local` on the host"). Living here lets them do a second job at no extra cost.

## They are now the end-to-end tests

`tests/integration/test_toy_solutions.py` runs all three on every CI build and asserts their **self-checking artifacts**, so a pass means the distributed run computed the right answer — not merely that it exited zero.

| Solution | Flow type | What it gates | Assertion |
|---|---|---|---|
| `toy_calculator` | BATCH | fan-out, trace join re-aligning branches across competing replicas, stateful aggregation, two-parent consumer, `metadata=True` consumer, prep hook | `report.json` → `matches_expected` |
| `toy_router` | BATCH | `partition_by` routing, `ctx.set_partition_key`, `async def process`, replica identity, idempotent sink | `counts.json` → `matches_expected` **and** `sticky` |
| `toy_fusion` | REALTIME | producers with no shared lineage fused by event time; `tolerance_ms`/`quorum`/`collect`; unbounded sources | `fusion_summary.json` → complete moments |

This covers ground no in-process test reaches. The two `toy_router` assertions are deliberately separate claims: I verified by running it with `partition_by: trace_id` that `sticky` goes `false` while `matches_expected` stays `true` — a routing regression that preserves totals is exactly what the second assertion catches.

Whole suite adds ~25s.

## Two load-bearing test decisions

Both are documented in the test's module docstring, because both look like complications worth "simplifying" away:

- **Each run copies the solution to a tmpdir.** `load_flow` calls `build_flow()` with no arguments, so a solution always reads the `config.yaml` next to its own module — `--config` reaches only `prepare.py`. Copying is the only way to give a run its own config and work_dir without writing into the repo.
- **Each runs as a subprocess via `videoflow run-local`.** All three ship a `common.py`, so importing two into one interpreter would collide on it — and a subprocess is also the honest reproduction of how these actually run.

## Notes

- The only code change to the moved files is one import-block separation ruff now wants: `videoflow` is first-party here and was third-party in contrib.
- Dockerfiles/READMEs updated for the new repo root; `.gitignore` picks up `solutions/*/config.yaml` and run artifacts.
- Docs updated in the same commit per the repo convention: `CLAUDE.md` (repo map + a section on the dual test/example role), root `README.md`, `docs/source/first-steps/`, and a new `solutions/README.md`.

## Verification

`uv run pytest tests/ -q` → **392 passed**; `uv run mypy` clean; `uv run ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
